### PR TITLE
Add subnet filtering to the CLI tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ lint:
 .PHONY: test
 test: dep cache lint
 ifndef GOOS
-	go test -v ./aws
+	go test -v ./aws ./cmd/cni-ipvlan-vpc-k8s-tool
 else
 	@echo Tests not available when cross-compiling
 endif

--- a/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
+++ b/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
@@ -237,7 +237,7 @@ func main() {
 			ArgsUsage: "[--subnet_filter=k,v] [security_group_ids...]",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name: "subnet_filter",
+					Name:  "subnet_filter",
 					Usage: "Comma separated key=value filters to restrict subnets",
 				},
 			},

--- a/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
+++ b/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
@@ -235,6 +235,12 @@ func main() {
 			Usage:     "Create a new interface",
 			Action:    actionNewInterface,
 			ArgsUsage: "[--subnet_filter=k,v] [security_group_ids...]",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name: "subnet_filter",
+					Usage: "Comma separated key=value filters to restrict subnets",
+				},
+			},
 		},
 		{
 			Name:      "remove-interface",

--- a/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool_test.go
+++ b/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestFilterBuildNil checks the empty string input
+func TestFilterBuildNil(t *testing.T) {
+	ret, err := filterBuild("")
+	if ret != nil && err != nil {
+		t.Errorf("Nil input wasn't nil")
+	}
+}
+
+// TestFilterBuildSingle tests a single filter
+func TestFilterBuildSingle(t *testing.T) {
+	ret, err := filterBuild("foo=bar")
+	if err != nil {
+		t.Errorf("Error returned")
+	}
+	if v, ok := ret["foo"]; !ok || v != "bar" {
+		t.Errorf("Invalid return from filter")
+	}
+}
+
+// TestFilterBuildMulti tests multiple filters
+func TestFilterBuildMulti(t *testing.T) {
+	ret, err := filterBuild("foo=bar,err=frr")
+	if err != nil {
+		t.Errorf("Error returned")
+	}
+	if v, ok := ret["foo"]; !ok || v != "bar" {
+		t.Errorf("Invalid return from filter - no foo")
+	}
+	if v, ok := ret["err"]; !ok || v != "frr" {
+		t.Errorf("Invalid return from filter - no frr")
+	}
+
+}


### PR DESCRIPTION
Allows the same subnet filters to be specified on the command line when allocating a new interface as in the IPAM configuration. 

Example:

    ./cni-ipvlan-vpc-k8s-tool new-interface --subnet_filter=kubernetes_kubelet=true sg-1234567