### PR TITLE
Enumerate docker network namespaces a different way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 vendor/
 vendor.orig/
 
-cni-ipvlan-vpc-k8s-*
+/cni-ipvlan-vpc-k8s-*
 *.tar.gz
 
 # Test binary, build with `go test -c`

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -117,6 +117,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "54cde6336808d285f98085f27e8b25e1aab2580a2cd65cfbeb50b09536d3dadb"
+  inputs-digest = "d9f9d6359192be11032284305954f01f4f7abad6f8449e60769e9f8e0ecac645"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/nl/desc.go
+++ b/nl/desc.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path/filepath"
 
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
@@ -64,7 +65,7 @@ func GetIPs() ([]BoundIP, error) {
 	} else {
 		for _, file := range files {
 			namespaces = append(namespaces,
-				fmt.Sprintf("/var/run/netns/%s", file.Name()))
+				filepath.Join("/var/run/netns", file.Name()))
 		}
 	}
 
@@ -85,7 +86,7 @@ func GetIPs() ([]BoundIP, error) {
 		return nil, err
 	}
 
-	// Enter each _named_ namesapce, get handles
+	// Enter each namesapce, get handles
 	for _, f := range namespaces {
 		nsHandle, err := netns.GetFromPath(f)
 		if err != nil {

--- a/nl/docker.go
+++ b/nl/docker.go
@@ -1,0 +1,57 @@
+package nl
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"golang.org/x/net/context"
+)
+
+// With a heavy heart and deep internal sadness, we support Docker
+func runningDockerContainers() (containerIDs []string, err error) {
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		return nil, err
+	}
+	defer cli.Close()
+
+	containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, container := range containers {
+		containerIDs = append(containerIDs, container.ID)
+	}
+	return containerIDs, nil
+}
+
+func dockerNetworkNamespace(containerID string) (string, error) {
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		return "", err
+	}
+	defer cli.Close()
+	r, err := cli.ContainerInspect(context.Background(), containerID)
+	if err != nil {
+		return "", nil
+	}
+
+	if r.State.Pid == 0 {
+		// Container has exited
+		return "", fmt.Errorf("Container has exited %v", containerID)
+	}
+	return fmt.Sprintf("/proc/%v/ns/net", r.State.Pid), nil
+}
+
+// Retrieve all namespaces from all running docker containers
+func dockerNetworkNamespaces(containerIDs []string) (namespaces []string) {
+	for _, containerID := range containerIDs {
+		cid, err := dockerNetworkNamespace(containerID)
+		if err == nil && len(cid) > 0 {
+			namespaces = append(namespaces, cid)
+		}
+	}
+	return
+}


### PR DESCRIPTION
This is testing code to address #9. The Docker namespace code is the same code path that Kubernetes 1.7 takes. 