### PR TITLE
retain source IPs when hitting service IPs via kube-proxy

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,8 +10,8 @@
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
   packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/ec2query","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/ec2","service/ec2/ec2iface","service/sts"]
-  revision = "e6c5e190452424b404ecdb81d6e3991d46b18e9d"
-  version = "v1.12.26"
+  revision = "03f37be7b3c2cec3a839ff74dea774c63819d45d"
+  version = "v1.12.50"
 
 [[projects]]
   name = "github.com/containernetworking/cni"
@@ -58,8 +58,8 @@
 [[projects]]
   name = "github.com/go-ini/ini"
   packages = ["."]
-  revision = "f280b3ba517bf5fc98922624f21fb0e7a92adaec"
-  version = "v1.30.3"
+  revision = "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a"
+  version = "v1.32.0"
 
 [[projects]]
   branch = "master"
@@ -94,7 +94,7 @@
   branch = "master"
   name = "github.com/vishvananda/netlink"
   packages = [".","nl"]
-  revision = "63ca7e48f59f463578ae6b6e839bef6906f048e2"
+  revision = "3ff4c2196115d804aa1c747781ad2b2a5c73e140"
 
 [[projects]]
   branch = "master"
@@ -106,17 +106,17 @@
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","context/ctxhttp","proxy"]
-  revision = "a337091b0525af65de94df2eb7e98bd9962dcbe2"
+  revision = "d866cfc389cec985d6fda2859936a575a55a3ab6"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "1e2299c37cc91a509f1b12369872d27be0ce98a6"
+  revision = "571f7bbbe08da2a8955aed9d4db316e78630e9a3"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "54cde6336808d285f98085f27e8b25e1aab2580a2cd65cfbeb50b09536d3dadb"
+  inputs-digest = "02bb9c184bbc694b0eef0583ab796d5b382767b405be6340ed3157599b0b8663"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -95,12 +95,10 @@ devices. Source and destination IPs are the well-known Kubernetes
 addresses on either side of the connect.
 
 * kube-proxy: We use kube-proxy in iptables mode and it functions as
-  expected, but with the caveat that Kubernetes Services see
-  connections from a node’s source IP instead of the Pod’s source IP
-  as the netfilter rules are processed in the default namespace. This
-  side effect is similar to Kubernetes behavior under the userspace
-  proxy. Since we’re optimizing for services connecting via the Envoy
-  mesh, this particular tradeoff hasn’t been a significant issue.
+  expected. The Pod's source IP is retained -- Kubernetes Services see
+  connections from the Pod's source IP. The unnumbered point-to-point
+  interface is used to loop traffic between kube-proxy in the default
+  namespace for outbound connections created in the Pod namespace.
 * [kube2iam](https://github.com/jtblin/kube2iam): Traffic from Pods to
   the AWS Metadata service transits over the unnumbered point-to-point
   interface to reach the default namespace before being redirected via

--- a/plugin/unnumbered-ptp/unnumbered-ptp.go
+++ b/plugin/unnumbered-ptp/unnumbered-ptp.go
@@ -144,7 +144,7 @@ func setupSNAT(ifName string, comment string) error {
 }
 
 func findFreeTable(start int) (int, error) {
-	m := make(map[int]bool)
+	allocatedTableIDs := make(map[int]bool)
 	// combine V4 and V6 tables
 	for _, family := range []int{netlink.FAMILY_V4, netlink.FAMILY_V6} {
 		rules, err := netlink.RuleList(family)
@@ -152,12 +152,12 @@ func findFreeTable(start int) (int, error) {
 			return -1, err
 		}
 		for _, rule := range rules {
-			m[rule.Table] = true
+			allocatedTableIDs[rule.Table] = true
 		}
 	}
 	// find first slot that's available for both V4 and V6 usage
 	for i := start; i < math.MaxUint32; i++ {
-		if m[i] == false {
+		if allocatedTableIDs[i] == false {
 			return i, nil
 		}
 	}

--- a/plugin/unnumbered-ptp/unnumbered-ptp.go
+++ b/plugin/unnumbered-ptp/unnumbered-ptp.go
@@ -40,6 +40,10 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+// constants for full jitter backoff in milliseconds
+const minSleep = 10000 // 10.00s
+const baseSleep = 20   //  0.02s
+
 func init() {
 	// this ensures that main runs only on main thread (thread group leader).
 	// since namespace ops (unshare, setns) are done for a single thread, we
@@ -301,7 +305,8 @@ func setupHostVeth(vethName string, hostAddrs []netlink.Addr, masq bool, tableSt
 						if k == 0 {
 							// failed to create initial route so sleep and try again
 							table = -1
-							wait := time.Duration(rand.Intn(int(math.Min(10000, 20*math.Pow(2, float64(j)))))) * time.Millisecond
+							wait := time.Duration(rand.Intn(int(math.Min(minSleep,
+								baseSleep*math.Pow(2, float64(j)))))) * time.Millisecond
 							fmt.Fprintf(os.Stderr, "route table collision, retrying in %v\n", wait)
 							time.Sleep(wait)
 							break

--- a/plugin/unnumbered-ptp/unnumbered-ptp.go
+++ b/plugin/unnumbered-ptp/unnumbered-ptp.go
@@ -316,13 +316,13 @@ func setupHostVeth(vethName string, hostAddrs []netlink.Addr, masq bool, tableSt
 			if table == -1 {
 				return fmt.Errorf("unable to find free route table")
 			}
-			// add source route for traffic originating from a Pod
+			// add policy route for traffic originating from a Pod
 			rule := netlink.NewRule()
 			rule.IifName = vethName
 			rule.Table = table
 			err = netlink.RuleAdd(rule)
 			if err != nil {
-				return fmt.Errorf("failed to add host rule src %v: %v", rule, err)
+				return fmt.Errorf("failed to add policy rule %v: %v", rule, err)
 			}
 		}
 	}

--- a/plugin/unnumbered-ptp/unnumbered-ptp.go
+++ b/plugin/unnumbered-ptp/unnumbered-ptp.go
@@ -289,7 +289,7 @@ func setupHostVeth(vethName string, hostAddrs []netlink.Addr, masq bool, tableSt
 			// try 10 times to find a table slot
 			for j := 0; j < 10 && table == -1; j++ {
 				// jitter looking for an initial free table slot
-				table, err = findFreeTable(tableStart + rand.Intn(500))
+				table, err = findFreeTable(tableStart + rand.Intn(1000))
 				if err != nil {
 					return fmt.Errorf("error listing ip rules %v", err)
 				}


### PR DESCRIPTION
Use IP policy routing to loop traffic back through Pods following kube-proxy service IP resolution to retain source IPs.