### PR TITLE
Refactor the AWS client and add subnet caching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ lint:
 .PHONY: test
 test: dep cache lint
 ifndef GOOS
-	go test -v ./aws ./nl ./cmd/cni-ipvlan-vpc-k8s-tool
+	go test -v ./aws/... ./nl ./cmd/cni-ipvlan-vpc-k8s-tool
 else
 	@echo Tests not available when cross-compiling
 endif

--- a/aws/cache/cacheable.go
+++ b/aws/cache/cacheable.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	cacheRoot    = "/var/run/user"
+	cacheRoot    = "/run/user"
 	cacheProgram = "cni-ipvlan-vpc-k8s"
 )
 
@@ -69,7 +69,7 @@ func ensureDirectory() error {
 		return nil
 	}
 
-	err = os.Mkdir(cachePath, os.ModeDir|0700)
+	err = os.MkdirAll(cachePath, os.ModeDir|0700)
 	return err
 }
 

--- a/aws/cache/cacheable.go
+++ b/aws/cache/cacheable.go
@@ -1,0 +1,135 @@
+package cache
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"time"
+)
+
+const (
+	cacheRoot    = "/var/run/user"
+	cacheProgram = "cni-ipvlan-vpc-k8s"
+)
+
+// State defines the return of the Store and Get calls
+type State int
+
+const (
+	// CacheFound means the key was found and valid
+	CacheFound State = iota
+	// CacheExpired means the key was found, but has expired. The value returned is not valid.
+	CacheExpired
+	// CacheNoEntry means the key was not found.
+	CacheNoEntry
+	// CacheNotAvailable means the cache system is not working as expected and has an internal error
+	CacheNotAvailable
+)
+
+func cachePath() string {
+	return path.Join(cacheRoot, fmt.Sprintf("%d", os.Getuid()), cacheProgram)
+}
+
+// JSONTime is a RFC3339 encoded time with JSON marshallers
+type JSONTime struct {
+	time.Time
+}
+
+// MarshalJSON marshals a JSONTime to an RFC3339 string
+func (j *JSONTime) MarshalJSON() ([]byte, error) {
+	return json.Marshal(j.Time.Format(time.RFC3339))
+}
+
+// UnmarshalJSON unmarshals a JSONTime to a time.Time
+func (j *JSONTime) UnmarshalJSON(js []byte) error {
+	var rawString string
+	err := json.Unmarshal(js, &rawString)
+	if err != nil {
+		return err
+	}
+	t, err := time.Parse(time.RFC3339, rawString)
+	if err != nil {
+		return err
+	}
+	j.Time = t
+	return nil
+}
+
+// Cacheable defines metadata for objects which can be cached to files as JSON
+type Cacheable struct {
+	Expires  JSONTime    `json:"_expires"`
+	Contents interface{} `json":contents"`
+}
+
+func ensureDirectory() error {
+	cachePath := cachePath()
+	info, err := os.Stat(cachePath)
+	if err == nil && info.IsDir() {
+		return nil
+	}
+
+	err = os.Mkdir(cachePath, os.ModeDir|0700)
+	return err
+}
+
+// Get gets a key from the named cache file
+func Get(key string, decodeTo interface{}) State {
+	err := ensureDirectory()
+	if err != nil {
+		return CacheNotAvailable
+	}
+
+	file, err := os.Open(path.Join(cachePath(), key))
+	if err != nil {
+		return CacheNoEntry
+	}
+
+	defer file.Close()
+
+	var contents Cacheable
+	contents.Contents = decodeTo
+	decoder := json.NewDecoder(file)
+	err = decoder.Decode(&contents)
+	if err != nil {
+		return CacheNoEntry
+	}
+
+	if contents.Expires.Time.Before(time.Now()) {
+		return CacheExpired
+	}
+
+	return CacheFound
+}
+
+// Store stores the given data interface as a JSON file with a given expiration time
+// under the given key.
+func Store(key string, lifetime time.Duration, data interface{}) State {
+	err := ensureDirectory()
+	if err != nil {
+		return CacheNotAvailable
+	}
+
+	key = path.Join(cachePath(), key)
+
+	file, err := os.OpenFile(key, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		return CacheNotAvailable
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	if encoder == nil {
+		return CacheNotAvailable
+	}
+
+	var contents Cacheable
+	contents.Expires.Time = time.Now().Add(lifetime)
+	contents.Contents = data
+	err = encoder.Encode(&contents)
+	if err != nil {
+		return CacheNotAvailable
+	}
+
+	return CacheFound
+}

--- a/aws/cache/cacheable_test.go
+++ b/aws/cache/cacheable_test.go
@@ -1,0 +1,74 @@
+package cache
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+type Foo struct {
+	TheTime JSONTime `json:"time"`
+}
+
+type Thing struct {
+	Value  string `json:"value"`
+	TValue int
+}
+
+func TestJSONTime_MarshalJSON(t *testing.T) {
+	input := Foo{JSONTime{time.Date(2017, 1, 1, 1, 1, 0, 0, time.UTC)}}
+	output, err := json.Marshal(&input)
+	if err != nil {
+		t.Error(err)
+	}
+	if string(output) != `{"time":"2017-01-01T01:01:00Z"}` {
+		t.Error(string(output))
+	}
+}
+
+func TestJSONTime_UnmarshalJSON(t *testing.T) {
+	input := []byte(`{"time":"2017-01-01T01:01:00Z"}`)
+	var foo Foo
+	err := json.Unmarshal(input, &foo)
+	if err != nil {
+		t.Error(err)
+	}
+	expected := Foo{JSONTime{time.Date(2017, 1, 1, 1, 1, 0, 0, time.UTC)}}
+	if !foo.TheTime.Time.Equal(expected.TheTime.Time) {
+		t.Errorf("Times were not equal: %v %v %v", foo.TheTime.Time, expected.TheTime.Time, foo)
+	}
+}
+
+func TestGet(t *testing.T) {
+	var d Thing
+	state := Get("key_not_exist", &d)
+	if state != CacheNoEntry {
+		t.Errorf("Empty cache did not return a valid state %v", state)
+	}
+
+	d.Value = "Hello"
+	d.TValue = 12
+
+	state = Store("hello", 30*time.Second, &d)
+	if state != CacheFound {
+		t.Errorf("Invalid store of the cache key %v", state)
+	}
+
+	var e Thing
+	state = Get("hello", &e)
+	if state != CacheFound {
+		t.Errorf("Can't reload existing key %v", state)
+	}
+
+	if d.Value != e.Value && d.TValue != e.TValue {
+		t.Errorf("%v != %v", d, t)
+	}
+
+	// Test expiration
+	Store("hello2", 1*time.Millisecond, &d)
+	time.Sleep(100 * time.Millisecond)
+	state = Get("hello2", &e)
+	if state != CacheExpired {
+		t.Error("Cache did not expire")
+	}
+}

--- a/aws/client_test.go
+++ b/aws/client_test.go
@@ -7,15 +7,15 @@ import (
 )
 
 func TestClientCreate(t *testing.T) {
-	oldIDDoc := _idDoc
-	defer func() { _idDoc = oldIDDoc }()
+	oldIDDoc := defaultClient.idDoc
+	defer func() { defaultClient.idDoc = oldIDDoc }()
 
-	_idDoc = &ec2metadata.EC2InstanceIdentityDocument{
+	defaultClient.idDoc = &ec2metadata.EC2InstanceIdentityDocument{
 		Region:           "us-east-1",
 		AvailabilityZone: "us-east-1a",
 	}
 
-	client, err := newEC2()
+	client, err := defaultClient.newEC2()
 	if err != nil {
 		t.Errorf("Error generated %v", err)
 	}
@@ -24,7 +24,7 @@ func TestClientCreate(t *testing.T) {
 		t.Errorf("No client returned %v", err)
 	}
 
-	client2, err := newEC2()
+	client2, err := defaultClient.newEC2()
 	if client != client2 {
 		t.Errorf("Clients returned were not identical (no caching)")
 	}

--- a/aws/interface_test.go
+++ b/aws/interface_test.go
@@ -78,10 +78,10 @@ func TestRemoveInterface(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		_ec2Client = &ec2ClientMock{
+		defaultClient.ec2Client = &ec2ClientMock{
 			NetworkDescribeResponse: c.NetworkDescribeResponse,
 		}
-		err := RemoveInterface(c.Input)
+		err := defaultClient.RemoveInterface(c.Input)
 
 		if err != nil {
 			t.Fatalf("%d Mock returned an error: %v", i, err)
@@ -101,8 +101,8 @@ func TestDeleteInterface(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		_ec2Client = &ec2ClientMock{NetworkDeleteResponse: c.Response}
-		err := deleteInterface(c.Input)
+		defaultClient.ec2Client = &ec2ClientMock{NetworkDeleteResponse: c.Response}
+		err := defaultClient.deleteInterface(c.Input)
 
 		if err != nil {
 			t.Fatalf("%d Mock returned an error: %v", i, err)
@@ -144,8 +144,8 @@ func TestWaitUntilInterfaceDetaches(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		_ec2Client = &ec2ClientMock{NetworkDescribeResponse: c.Response}
-		err := waitUtilInterfaceDetaches(c.Input)
+		defaultClient.ec2Client = &ec2ClientMock{NetworkDescribeResponse: c.Response}
+		err := defaultClient.waitUtilInterfaceDetaches(c.Input)
 
 		if err != nil {
 			if err.Error() != c.Expected {
@@ -188,8 +188,8 @@ func TestDescribeNetworkInterface(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		_ec2Client = &ec2ClientMock{NetworkDescribeResponse: c.Response}
-		res, err := describeNetworkInterface(c.Input)
+		defaultClient.ec2Client = &ec2ClientMock{NetworkDescribeResponse: c.Response}
+		res, err := defaultClient.describeNetworkInterface(c.Input)
 
 		if err != nil {
 			if err.Error() != "Cannot describe interface, it might not exist" {

--- a/aws/limits.go
+++ b/aws/limits.go
@@ -7,6 +7,11 @@ type ENILimit struct {
 	IPv6     int
 }
 
+// LimitsClient provides methods for locating limits in AWS
+type LimitsClient interface {
+	ENILimits() ENILimit
+}
+
 var eniLimits map[string]ENILimit
 
 func init() {
@@ -112,8 +117,8 @@ func ENILimitsForInstanceType(itype string) (limit ENILimit) {
 }
 
 // ENILimits returns the limits based on the system's instance type
-func ENILimits() ENILimit {
-	id, err := getIDDoc()
+func (c *awsclient) ENILimits() ENILimit {
+	id, err := c.getIDDoc()
 	if err != nil || id == nil {
 		return ENILimit{}
 	}

--- a/aws/limits_test.go
+++ b/aws/limits_test.go
@@ -7,16 +7,16 @@ import (
 )
 
 func TestLimitsReturn(t *testing.T) {
-	oldIDDoc := _idDoc
-	defer func() { _idDoc = oldIDDoc }()
+	oldIDDoc := defaultClient.idDoc
+	defer func() { defaultClient.idDoc = oldIDDoc }()
 
-	_idDoc = &ec2metadata.EC2InstanceIdentityDocument{
+	defaultClient.idDoc = &ec2metadata.EC2InstanceIdentityDocument{
 		Region:           "us-east-1",
 		AvailabilityZone: "us-east-1a",
 		InstanceType:     "r4.xlarge",
 	}
 
-	limits := ENILimits()
+	limits := defaultClient.ENILimits()
 	if limits.Adapters != 4 && limits.IPv4 != 15 {
 		t.Fatalf("No valid limit returned for r4.xlarge %v", limits)
 	}

--- a/aws/subnets_test.go
+++ b/aws/subnets_test.go
@@ -45,18 +45,18 @@ func TestGetSubnetsForInstance(t *testing.T) {
 		},
 	}
 
-	oldIDDoc := _idDoc
-	defer func() { _idDoc = oldIDDoc }()
+	oldIDDoc := defaultClient.idDoc
+	defer func() { defaultClient.idDoc = oldIDDoc }()
 
-	_idDoc = &ec2metadata.EC2InstanceIdentityDocument{
+	defaultClient.idDoc = &ec2metadata.EC2InstanceIdentityDocument{
 		Region:           "us-east-1",
 		AvailabilityZone: "us-east-1a",
 	}
 
 	for i, c := range cases {
-		_ec2Client = &ec2SubnetsMock{Resp: c.Resp}
+		defaultClient.ec2Client = &ec2SubnetsMock{Resp: c.Resp}
 
-		res, err := GetSubnetsForInstance()
+		res, err := defaultClient.GetSubnetsForInstance()
 		if err != nil {
 			t.Fatalf("%d Mock returned an error - is it mocked? %v", i, err)
 		}

--- a/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
+++ b/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
@@ -54,7 +54,7 @@ func actionNewInterface(c *cli.Context) error {
 			fmt.Println("please specify security groups")
 			return fmt.Errorf("need security groups")
 		}
-		newIf, err := aws.NewInterface(secGrps, filters)
+		newIf, err := aws.DefaultClient.NewInterface(secGrps, filters)
 		if err != nil {
 			fmt.Println(err)
 			return err
@@ -74,7 +74,7 @@ func actionRemoveInterface(c *cli.Context) error {
 			return fmt.Errorf("Insufficent Arguments")
 		}
 
-		if err := aws.RemoveInterface(interfaces); err != nil {
+		if err := aws.DefaultClient.RemoveInterface(interfaces); err != nil {
 			fmt.Println(err)
 			return err
 		}
@@ -99,7 +99,7 @@ func actionDeallocate(c *cli.Context) error {
 				return fmt.Errorf("IP parse error")
 			}
 
-			err := aws.DeallocateIP(&ip)
+			err := aws.DefaultClient.DeallocateIP(&ip)
 			if err != nil {
 				fmt.Printf("deallocation failed: %v\n", err)
 				return err
@@ -112,7 +112,7 @@ func actionDeallocate(c *cli.Context) error {
 func actionAllocate(c *cli.Context) error {
 	return cniipvlanvpck8s.LockfileRun(func() error {
 		index := c.Int("index")
-		res, err := aws.AllocateIPFirstAvailableAtIndex(index)
+		res, err := aws.DefaultClient.AllocateIPFirstAvailableAtIndex(index)
 		if err != nil {
 			fmt.Println(err)
 			return err
@@ -142,7 +142,7 @@ func actionFreeIps(c *cli.Context) error {
 }
 
 func actionLimits(c *cli.Context) error {
-	limit := aws.ENILimits()
+	limit := aws.DefaultClient.ENILimits()
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "adapters\tipv4\tipv6\t")
 	fmt.Fprintf(w, "%v\t%v\t%v\t\n", limit.Adapters,
@@ -171,7 +171,7 @@ func actionAddr(c *cli.Context) error {
 }
 
 func actionEniIf(c *cli.Context) error {
-	interfaces, err := aws.GetInterfaces()
+	interfaces, err := aws.DefaultClient.GetInterfaces()
 	if err != nil {
 		fmt.Println(err)
 		return err
@@ -196,7 +196,7 @@ func actionEniIf(c *cli.Context) error {
 }
 
 func actionSubnets(c *cli.Context) error {
-	subnets, err := aws.GetSubnetsForInstance()
+	subnets, err := aws.DefaultClient.GetSubnetsForInstance()
 	if err != nil {
 		fmt.Println(err)
 		return err
@@ -218,7 +218,7 @@ func actionSubnets(c *cli.Context) error {
 }
 
 func main() {
-	if !aws.Available() {
+	if !aws.DefaultClient.Available() {
 		fmt.Fprintln(os.Stderr, "This command must be run from a running ec2 instance")
 		os.Exit(1)
 	}

--- a/freeip.go
+++ b/freeip.go
@@ -13,7 +13,7 @@ import (
 func FindFreeIPsAtIndex(index int) ([]*aws.AllocationResult, error) {
 	freeIps := []*aws.AllocationResult{}
 
-	interfaces, err := aws.GetInterfaces()
+	interfaces, err := aws.DefaultClient.GetInterfaces()
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/ipam/main.go
+++ b/plugin/ipam/main.go
@@ -91,10 +91,10 @@ func cmdAdd(args *skel.CmdArgs) error {
 		alloc = free[0]
 	} else {
 		// allocate an IP on an available interface
-		alloc, err = aws.AllocateIPFirstAvailableAtIndex(conf.IPAM.IfaceIndex)
+		alloc, err = aws.DefaultClient.AllocateIPFirstAvailableAtIndex(conf.IPAM.IfaceIndex)
 		if err != nil {
 			// failed, so attempt to add an IP to a new interface
-			newIf, err := aws.NewInterface(conf.IPAM.SecGroupIds, conf.IPAM.SubnetTags)
+			newIf, err := aws.DefaultClient.NewInterface(conf.IPAM.SecGroupIds, conf.IPAM.SubnetTags)
 			// If this interface has somehow gained more than one IP since being allocated,
 			// abort this process and let a subsequent run find a valid IP.
 			if err != nil || len(newIf.IPv4s) != 1 {
@@ -180,7 +180,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	if !conf.IPAM.SkipDeallocation {
 		// deallocate IPs outside of the namespace so creds are correct
 		for _, addr := range addrs {
-			aws.DeallocateIP(&addr.IP)
+			aws.DefaultClient.DeallocateIP(&addr.IP)
 		}
 	}
 	return nil


### PR DESCRIPTION
- All of the AWS subcomponents are now behind interfaces scoped to
  their function.
- Add a simple JSON file cache library
- Cache the GetSubnetsForInstance call for one minute. For allocating
  any interfaces this is going to be the highest volume call that we
  can avoid making.