### PR TITLE
Only use user-specific run cache for non-UID0 invocation

### DIFF
--- a/aws/cache/cacheable.go
+++ b/aws/cache/cacheable.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	cacheRoot    = "/run/user"
+	cacheRoot    = "/run"
 	cacheProgram = "cni-ipvlan-vpc-k8s"
 )
 
@@ -28,7 +28,12 @@ const (
 )
 
 func cachePath() string {
-	return path.Join(cacheRoot, fmt.Sprintf("%d", os.Getuid()), cacheProgram)
+	uid := os.Getuid()
+	if uid != 0 {
+		return path.Join(cacheRoot, "user", fmt.Sprintf("%d", os.Getuid()), cacheProgram)
+	}
+
+	return path.Join(cacheRoot, cacheProgram)
 }
 
 // JSONTime is a RFC3339 encoded time with JSON marshallers

--- a/aws/client.go
+++ b/aws/client.go
@@ -23,7 +23,7 @@ type awsclient struct {
 }
 
 type combinedClient struct {
-	*subnetsClient
+	*subnetsCacheClient
 	*awsclient
 	*interfaceClient
 	*allocateClient
@@ -50,7 +50,7 @@ func init() {
 		1 * time.Minute,
 	}
 	defaultClient = &combinedClient{
-		&subnetsClient{awsClient},
+		subnets,
 		awsClient,
 		&interfaceClient{awsClient, subnets},
 		&allocateClient{awsClient, subnets},


### PR DESCRIPTION
Also actually use the cached subnet client