### PR TITLE
Don't rely on the meta-data response if buggy

### DIFF
--- a/aws/bugs.go
+++ b/aws/bugs.go
@@ -1,0 +1,19 @@
+package aws
+
+import (
+	"strings"
+)
+
+// HasBugBrokenVPCCidrs returns true if this instance has a known defective
+// meta-data service which will not return secondary VPC CIDRs. As of January 2018,
+// this covers c5 and m5 class hardware.
+func HasBugBrokenVPCCidrs(meta MetadataClient) bool {
+	itype := meta.InstanceType()
+	family := strings.Split(itype, ".")[0]
+	switch family {
+	case "c5", "m5":
+		return true
+	default:
+		return false
+	}
+}

--- a/aws/bugs.go
+++ b/aws/bugs.go
@@ -4,6 +4,25 @@ import (
 	"strings"
 )
 
+// Bug defines a bug name and a function to check if the
+// system is affected
+type Bug struct {
+	Name   string
+	HasBug func() bool
+}
+
+// ListBugs returns an enumerated set of all known bugs in AWS or instances
+// that this instance is afflicted by
+func ListBugs(meta MetadataClient) []Bug {
+	bugs := []Bug{
+		{
+			Name:   "broken_cidr",
+			HasBug: func() bool { return HasBugBrokenVPCCidrs(meta) },
+		},
+	}
+	return bugs
+}
+
 // HasBugBrokenVPCCidrs returns true if this instance has a known defective
 // meta-data service which will not return secondary VPC CIDRs. As of January 2018,
 // this covers c5 and m5 class hardware.

--- a/aws/client.go
+++ b/aws/client.go
@@ -27,6 +27,7 @@ type combinedClient struct {
 	*awsclient
 	*interfaceClient
 	*allocateClient
+	*vpcCacheClient
 }
 
 // Client offers all of the supporting AWS services
@@ -36,6 +37,7 @@ type Client interface {
 	MetadataClient
 	SubnetsClient
 	AllocateClient
+	VPCClient
 }
 
 var defaultClient *combinedClient
@@ -54,6 +56,10 @@ func init() {
 		awsClient,
 		&interfaceClient{awsClient, subnets},
 		&allocateClient{awsClient, subnets},
+		&vpcCacheClient{
+			&vpcclient{awsClient},
+			1 * time.Hour,
+		},
 	}
 
 	DefaultClient = defaultClient

--- a/aws/metadata.go
+++ b/aws/metadata.go
@@ -197,5 +197,10 @@ func (c *awsclient) GetInterfaces() ([]Interface, error) {
 
 // InstanceType gets the type of the instance, i.e. "c5.large"
 func (c *awsclient) InstanceType() string {
-	return c.idDoc.InstanceType
+	id, err := c.getIDDoc()
+	if err != nil {
+		return "unknown"
+	}
+
+	return id.InstanceType
 }

--- a/aws/metadata.go
+++ b/aws/metadata.go
@@ -40,6 +40,7 @@ func (a Interfaces) Less(i, j int) bool { return a[i].Number < a[j].Number }
 type MetadataClient interface {
 	Available() bool
 	GetInterfaces() ([]Interface, error)
+	InstanceType() string
 }
 
 // EC2 generally gives the following data blocks from an interface in meta-data
@@ -192,4 +193,9 @@ func (c *awsclient) GetInterfaces() ([]Interface, error) {
 	sort.Sort(Interfaces(interfaces))
 
 	return interfaces, nil
+}
+
+// InstanceType gets the type of the instance, i.e. "c5.large"
+func (c *awsclient) InstanceType() string {
+	return c.idDoc.InstanceType
 }

--- a/aws/vpc.go
+++ b/aws/vpc.go
@@ -1,0 +1,64 @@
+package aws
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+
+	"github.com/lyft/cni-ipvlan-vpc-k8s/aws/cache"
+)
+
+// VPCClient provides a view into a VPC
+type VPCClient interface {
+	DescribeVPCCIDRs(vpcID string) ([]*net.IPNet, error)
+}
+
+type vpcCacheClient struct {
+	vpc        *vpcclient
+	expiration time.Duration
+}
+
+func (v *vpcCacheClient) DescribeVPCCIDRs(vpcID string) (cidrs []*net.IPNet, err error) {
+	key := fmt.Sprintf("vpc-cidr-%v", vpcID)
+	state := cache.Get(key, &cidrs)
+	if state == cache.CacheFound {
+		return
+	}
+	cidrs, err = v.vpc.DescribeVPCCIDRs(vpcID)
+	if err != nil {
+		return nil, err
+	}
+	cache.Store(key, v.expiration, &cidrs)
+	return
+}
+
+type vpcclient struct {
+	aws *awsclient
+}
+
+// DescribeVPCCIDRs returns a list of all CIDRS associated with a VPC
+func (v *vpcclient) DescribeVPCCIDRs(vpcID string) ([]*net.IPNet, error) {
+	req := &ec2.DescribeVpcsInput{
+		VpcIds: []*string{aws.String(vpcID)},
+	}
+	res, err := v.aws.ec2Client.DescribeVpcs(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var cidrs []*net.IPNet
+
+	for _, vpc := range res.Vpcs {
+		for _, cblock := range vpc.CidrBlockAssociationSet {
+			_, parsed, err := net.ParseCIDR(*cblock.CidrBlock)
+			if err != nil {
+				return nil, err
+			}
+			cidrs = append(cidrs, parsed)
+		}
+	}
+	return cidrs, nil
+}

--- a/aws/vpc.go
+++ b/aws/vpc.go
@@ -44,7 +44,11 @@ func (v *vpcclient) DescribeVPCCIDRs(vpcID string) ([]*net.IPNet, error) {
 	req := &ec2.DescribeVpcsInput{
 		VpcIds: []*string{aws.String(vpcID)},
 	}
-	res, err := v.aws.ec2Client.DescribeVpcs(req)
+	ec2, err := v.aws.newEC2()
+	if err != nil {
+		return nil, err
+	}
+	res, err := ec2.DescribeVpcs(req)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
+++ b/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
@@ -70,7 +70,7 @@ func actionBugs(c *cli.Context) error {
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 		fmt.Fprintln(w, "bug\tafflicted\t")
 		for _, bug := range aws.ListBugs(aws.DefaultClient) {
-			fmt.Fprintf(w, "%s\t%s\t\n", bug.Name, bug.HasBug())
+			fmt.Fprintf(w, "%s\t%v\t\n", bug.Name, bug.HasBug())
 		}
 		w.Flush()
 		return nil


### PR DESCRIPTION
m5 and c5 instances have a broken meta-data service response when
there is more than one CIDR range in a VPC. On these instances, we
will not use the meta-data response but instead query the DescribeVpcs
AWS API output to determine which CIDRs are present.