### PR TITLE
Add routes to all peered VPCs (config option)

### DIFF
--- a/aws/vpc.go
+++ b/aws/vpc.go
@@ -14,6 +14,7 @@ import (
 // VPCClient provides a view into a VPC
 type VPCClient interface {
 	DescribeVPCCIDRs(vpcID string) ([]*net.IPNet, error)
+	DescribeVPCPeerCIDRs(vpcID string) ([]*net.IPNet, error)
 }
 
 type vpcCacheClient struct {
@@ -33,6 +34,21 @@ func (v *vpcCacheClient) DescribeVPCCIDRs(vpcID string) (cidrs []*net.IPNet, err
 	}
 	cache.Store(key, v.expiration, &cidrs)
 	return
+}
+
+func (v *vpcCacheClient) DescribeVPCPeerCIDRs(vpcID string) (cidrs []*net.IPNet, err error) {
+	key := fmt.Sprintf("vpc-peers-%v", vpcID)
+	state := cache.Get(key, &cidrs)
+	if state == cache.CacheFound {
+		return
+	}
+	cidrs, err = v.vpc.DescribeVPCPeerCIDRs(vpcID)
+	if err != nil {
+		return nil, err
+	}
+	cache.Store(key, v.expiration, &cidrs)
+	return
+
 }
 
 type vpcclient struct {
@@ -65,4 +81,51 @@ func (v *vpcclient) DescribeVPCCIDRs(vpcID string) ([]*net.IPNet, error) {
 		}
 	}
 	return cidrs, nil
+}
+
+// DescribeVPCPeerCIDRs returns a list of CIDRs for all peered VPCs to the given VPC
+func (v *vpcclient) DescribeVPCPeerCIDRs(vpcID string) ([]*net.IPNet, error) {
+	ec2c, err := v.aws.newEC2()
+	if err != nil {
+		return nil, err
+	}
+
+	req := &ec2.DescribeVpcPeeringConnectionsInput{}
+
+	res, err := ec2c.DescribeVpcPeeringConnections(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// In certain peering situations, a CIDR may be duplicated
+	// and visible to the API, even if the CIDR is not active in
+	// one of the peered VPCs. We store all of the CIDRs in a map
+	// to de-duplicate them.
+	cidrs := make(map[string]bool, 0)
+
+	for _, peering := range res.VpcPeeringConnections {
+		var peer *ec2.VpcPeeringConnectionVpcInfo
+
+		if vpcID == *peering.AccepterVpcInfo.VpcId {
+			peer = peering.RequesterVpcInfo
+		} else if vpcID == *peering.RequesterVpcInfo.VpcId {
+			peer = peering.AccepterVpcInfo
+		}
+
+		for _, cidrBlock := range peer.CidrBlockSet {
+			_, _, err := net.ParseCIDR(*cidrBlock.CidrBlock)
+			if err == nil {
+				cidrs[*cidrBlock.CidrBlock] = true
+			}
+		}
+	}
+
+	var returnCidrs []*net.IPNet
+	for cidrString := range cidrs {
+		_, cidr, err := net.ParseCIDR(cidrString)
+		if err == nil && cidr != nil {
+			returnCidrs = append(returnCidrs, cidr)
+		}
+	}
+	return returnCidrs, nil
 }

--- a/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
+++ b/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
@@ -228,6 +228,26 @@ func actionVpcCidr(c *cli.Context) error {
 	return nil
 }
 
+func actionVpcPeerCidr(c *cli.Context) error {
+	interfaces, err := aws.DefaultClient.GetInterfaces()
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "iface\tpeer_dcidr\t")
+	for _, iface := range interfaces {
+		apiCidrs, _ := aws.DefaultClient.DescribeVPCPeerCIDRs(iface.VpcID)
+
+		fmt.Fprintf(w, "%s\t%v\t\n",
+			iface.LocalName(),
+			apiCidrs)
+	}
+	w.Flush()
+	return nil
+}
+
 func actionSubnets(c *cli.Context) error {
 	subnets, err := aws.DefaultClient.GetSubnetsForInstance()
 	if err != nil {
@@ -330,9 +350,14 @@ func main() {
 			Usage:  "Show the VPC CIDRs associated with current interfaces",
 			Action: actionVpcCidr,
 		},
+		{
+			Name:   "vpcpeercidr",
+			Usage:  "Show the peered VPC CIDRs associated with current interfaces",
+			Action: actionVpcPeerCidr,
+		},
 	}
 	app.Version = version
-	app.Copyright = "(c) 2017 Lyft Inc."
+	app.Copyright = "(c) 2017-2018 Lyft Inc."
 	app.Usage = "Interface with ENI adapters and CNI bindings for those"
 	app.Run(os.Args)
 }


### PR DESCRIPTION
If the key `routeToVpcPeers` is set to `true` on the IPAM
configuration, all known peered VPC CIDRs will be added to the IPvlan
route table allowing for direct VPC<->VPC communication.

Fixes #21 / #23