### PR TITLE
Add a command to return max pods

### DIFF
--- a/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
+++ b/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
@@ -167,6 +167,12 @@ func actionLimits(c *cli.Context) error {
 	return nil
 }
 
+func actionMaxPods(c *cli.Context) error {
+	limit := aws.DefaultClient.ENILimits()
+	fmt.Printf("%d\n", (limit.Adapters - 1) * limit.IPv4)
+	return nil
+}
+
 func actionAddr(c *cli.Context) error {
 	ips, err := nl.GetIPs()
 	if err != nil {
@@ -396,6 +402,11 @@ func main() {
 			Name:   "limits",
 			Usage:  "Display limits for ENI for this instance type",
 			Action: actionLimits,
+		},
+		{
+			Name:   "maxpods",
+			Usage:  "Return a single number specifying the maximum number of pod addresses that can be use don this instance",
+			Action: actionMaxPods,
 		},
 		{
 			Name:   "bugs",

--- a/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
+++ b/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
@@ -405,7 +405,7 @@ func main() {
 		},
 		{
 			Name:   "maxpods",
-			Usage:  "Return a single number specifying the maximum number of pod addresses that can be use don this instance",
+			Usage:  "Return a single number specifying the maximum number of pod addresses that can be used on this instance",
 			Action: actionMaxPods,
 		},
 		{

--- a/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
+++ b/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
@@ -169,7 +169,7 @@ func actionLimits(c *cli.Context) error {
 
 func actionMaxPods(c *cli.Context) error {
 	limit := aws.DefaultClient.ENILimits()
-	fmt.Printf("%d\n", (limit.Adapters - 1) * limit.IPv4)
+	fmt.Printf("%d\n", (limit.Adapters-1)*limit.IPv4)
 	return nil
 }
 


### PR DESCRIPTION
Return the maximum number of pods an instance can have based on the
ENI limits known to the library.

Always returns (adapters -1)*ipv4_per_adapter