### PR TITLE
Tentative fix for containerd support

### DIFF
--- a/plugin/unnumbered-ptp/unnumbered-ptp.go
+++ b/plugin/unnumbered-ptp/unnumbered-ptp.go
@@ -236,12 +236,7 @@ func setupContainerVeth(netns ns.NetNS, ifName string, mtu int, hostAddrs []netl
 		containerInterface.Mac = contVeth0.HardwareAddr.String()
 		containerInterface.Sandbox = netns.Path()
 
-		for _, ipc := range pr.IPs {
-			// All addresses apply to the container veth interface
-			ipc.Interface = current.Int(1)
-		}
-
-		pr.Interfaces = []*current.Interface{hostInterface, containerInterface}
+		pr.Interfaces = append(pr.Interfaces, hostInterface, containerInterface)
 
 		contVeth, err := net.InterfaceByName(ifName)
 		if err != nil {

--- a/plugin/unnumbered-ptp/unnumbered-ptp.go
+++ b/plugin/unnumbered-ptp/unnumbered-ptp.go
@@ -233,7 +233,9 @@ func setupContainerVeth(netns ns.NetNS, ifName string, mtu int, hostAddrs []netl
 		hostInterface.Name = hostVeth.Name
 		hostInterface.Mac = hostVeth.HardwareAddr.String()
 		containerInterface.Name = contVeth0.Name
-		containerInterface.Mac = contVeth0.HardwareAddr.String()
+		// ip.SetupVeth does not retrieve MAC address from peer in veth
+		containerNetlinkIface, _ := netlink.LinkByName(contVeth0.Name)
+		containerInterface.Mac = containerNetlinkIface.Attrs().HardwareAddr.String()
 		containerInterface.Sandbox = netns.Path()
 
 		pr.Interfaces = append(pr.Interfaces, hostInterface, containerInterface)


### PR DESCRIPTION
Fixes #33 by avoiding to overwrite the output of the ipvlan plugin (interfaces) and not associating IPs created by the ipvlan plugin to veth0.

In addition, ip.SetupVeth does not retrieve MAC address from peer in veth so the field is empty. There is a method to create an net.interface from a netlink.link in package ```github.com/containernetworking/plugins/pkg/ip``` (ifaceFromNetlinkLink) but it is private, hence the ```containerNetlinkIface.Attrs().HardwareAddr.String()```. We could use a more elegant solution but this one is quite simple.

I tested it (really not extensively) with containerd and it works.

As explained in the issue, I may have missed something in the logic of unnumbered-ptp plugin regarding the current behavior.

**Plugin output before fix:**
```
sudo CNI_PATH=<current plugins> ./cnitool add cni-ipvlan-vpc-k8s /var/run/netns/testing
{
    "cniVersion": "0.3.1",
    "interfaces": [
        {
            "name": "veth6834765b",
            "mac": "ee:ec:bc:41:6d:f9"
        },
        {
            "name": "veth0",
            "sandbox": "/var/run/netns/testing"
        }
    ],
    "ips": [
        {
            "version": "4",
            "interface": 1,
            "address": "172.30.0.100/24",
            "gateway": "172.30.0.1"
        }
    ],
    "routes": [...],
    "dns": {}
```

**Plugin output with patch:**
```
sudo CNI_PATH=<patched plugins> ./cnitool add cni-ipvlan-vpc-k8s /var/run/netns/testing
{
    "cniVersion": "0.3.1",
    "interfaces": [
        {
            "name": "eth0",
            "mac": "02:57:ab:25:84:74",
            "sandbox": "/var/run/netns/testing"
        },
        {
            "name": "veth75a4ae7b",
            "mac": "a6:a5:22:eb:32:bd"
        },
        {
            "name": "veth0",
            "mac": "72:da:53:01:88:b9",
            "sandbox": "/var/run/netns/testing"
        }
    ],
    "ips": [
        {
            "version": "4",
            "interface": 0,
            "address": "172.30.0.100/24",
            "gateway": "172.30.0.1"
        }
    ],
    "routes": [...],
    "dns": {}
```