### PR TITLE
Returns error when vpc-ipv4-cidr-blocks is empty

### DIFF
--- a/aws/metadata.go
+++ b/aws/metadata.go
@@ -137,7 +137,11 @@ func (c *awsclient) getInterface(mac string) (Interface, error) {
 	}
 
 	if err := metadataParser("vpc-ipv4-cidr-blocks", func(iface *Interface, value string) error {
-		for _, vpcCidr := range strings.Split(value, "\n") {
+		cidrList := strings.Split(value, "\n")
+		if len(cidrList) == 0 {
+			return fmt.Errorf("No VPC ranges found")
+		}
+		for _, vpcCidr := range cidrList {
 			_, net, err := net.ParseCIDR(vpcCidr)
 			if err != nil {
 				return err


### PR DESCRIPTION
Addresses #36

I can convince myself that the metadata api wouldn't return a partial list of cidr ranges for a vpc. 