### PR TITLE
sneaky swallowed error

### DIFF
--- a/aws/metadata.go
+++ b/aws/metadata.go
@@ -69,7 +69,10 @@ func (c *awsclient) getInterface(mac string) (Interface, error) {
 		return c.metaData.GetMetadata(fmt.Sprintf("%s/%s", prefix, val))
 	}
 	metadataParser := func(metadataId string, modifer func(*Interface, string) error) error {
-		metadata, _ := get(metadataId)
+		metadata, err := get(metadataId)
+		if err != nil {
+			return err
+		}
 		if metadata != "" {
 			return modifer(&iface, metadata)
 		}

--- a/aws/metadata.go
+++ b/aws/metadata.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"sort"
 	"strconv"
@@ -71,6 +72,7 @@ func (c *awsclient) getInterface(mac string) (Interface, error) {
 	metadataParser := func(metadataId string, modifer func(*Interface, string) error) error {
 		metadata, err := get(metadataId)
 		if err != nil {
+			log.Printf("Error calling metadata service: %v", err)
 			return err
 		}
 		if metadata != "" {


### PR DESCRIPTION
After trying #37 out on a busier cluster I noticed that the problems we had with missing vpc routes still happened. I looked closer at the metadata.go code and it appears that we were still swallowing errors from the metadata service. These errors would have caused retries in the ipam plugin but they weren't bubbled up. I did some testing to cause mass rescheduling of pods onto new nodes that didn't have any extra ENIs attached. The idea was to cause as many instances as possible of the first pod or two that gets mapped to an ENI and observe the unstable behavior of the instance metadata service during this initialization time. The plugin logged many 404 errors right after the ENIs get attached but the errors got surfaced to the right place and after a few retries to the metadata service, the pod network always got set up correctly.

