### PR TITLE
Remove unicity constraint for ENI in subnets

### DIFF
--- a/aws/interface.go
+++ b/aws/interface.go
@@ -146,10 +146,6 @@ func (c *interfaceClient) NewInterface(secGrps []string, requiredTags map[string
 		return nil, err
 	}
 
-	if len(subnets) <= len(existingInterfaces) {
-		return nil, fmt.Errorf("not enough available subnets to make a new interface")
-	}
-
 	limits := c.aws.ENILimits()
 	if len(existingInterfaces) >= limits.Adapters {
 		return nil, fmt.Errorf("too many adapters on this instance already")
@@ -168,15 +164,7 @@ OUTER:
 				continue OUTER
 			}
 		}
-		var matched bool
-		for _, intf := range existingInterfaces {
-			if intf.SubnetID == newSubnet.ID {
-				matched = true
-			}
-		}
-		if !matched {
-			availableSubnets = append(availableSubnets, newSubnet)
-		}
+		availableSubnets = append(availableSubnets, newSubnet)
 	}
 
 	// assign new interfaces to subnets with most available addresses


### PR DESCRIPTION
Addresses #32 by removing checks for unicity (multiple interfaces can  now be created in the same subnet).

We went back a forth quite a bit between 2 approaches (see issue):
- remove all subnet logic and simply reuse the main interface
- keep all the subnet logic but remove unicity checks

We run some workloads outside of AWS and pods are in separate subnets so we finally decided to do the same on AWS, which requires subnet tags to identify pod subnets.

We have been running the plugin with this change for a few weeks and everything is working great so far