### PR TITLE
move to chained CNI execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.2 AS builder
+FROM golang:1.10.3 AS builder
 LABEL maintainer="mcutalo@lyft.com"
 
 WORKDIR /go/src/github.com/lyft/cni-ipvlan-vpc-k8s/

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,62 +4,128 @@
 [[projects]]
   name = "github.com/Microsoft/go-winio"
   packages = ["."]
-  revision = "78439966b38d69bf38227fbf57ac8a6fee70f69a"
-  version = "v0.4.5"
+  revision = "7da180ee92d8bd8bb8c37fc560e673e6557c392f"
+  version = "v0.4.7"
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/ec2query","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/ec2","service/ec2/ec2iface","service/sts"]
-  revision = "03f37be7b3c2cec3a839ff74dea774c63819d45d"
-  version = "v1.12.50"
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/sdkrand",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/ec2query",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/xml/xmlutil",
+    "service/ec2",
+    "service/ec2/ec2iface",
+    "service/sts"
+  ]
+  revision = "bff41fb23b7550368282029f6478819d6a99ae0f"
+  version = "v1.12.79"
 
 [[projects]]
   name = "github.com/containernetworking/cni"
-  packages = ["pkg/invoke","pkg/skel","pkg/types","pkg/types/020","pkg/types/current","pkg/version"]
+  packages = [
+    "pkg/invoke",
+    "pkg/skel",
+    "pkg/types",
+    "pkg/types/020",
+    "pkg/types/current",
+    "pkg/version"
+  ]
   revision = "a7885cb6f8ab03fba07852ded351e4f5e7a112bf"
   version = "v0.6.0"
 
 [[projects]]
   name = "github.com/containernetworking/plugins"
-  packages = ["pkg/ip","pkg/ipam","pkg/ns","pkg/utils","pkg/utils/hwaddr"]
-  revision = "7480240de9749f9a0a5c8614b17f1f03e0c06ab9"
-  version = "v0.6.0"
+  packages = [
+    "pkg/ip",
+    "pkg/ipam",
+    "pkg/ns",
+    "pkg/utils",
+    "pkg/utils/hwaddr",
+    "pkg/utils/sysctl"
+  ]
+  revision = "72b62babeeb3d7b25c9809ea9eb9fc9c02cc0f71"
+  version = "v0.7.1"
 
 [[projects]]
   name = "github.com/coreos/go-iptables"
   packages = ["iptables"]
-  revision = "259c8e6a4275d497442c721fa52204d7a58bde8b"
-  version = "v0.2.0"
+  revision = "b5b1876b170881a8259f036445ee89c8669db386"
+  version = "v0.3.0"
 
 [[projects]]
   name = "github.com/docker/distribution"
-  packages = ["digest","reference"]
+  packages = [
+    "digest",
+    "reference"
+  ]
   revision = "48294d928ced5dd9b378f7fd7c6f5da3ff3f2c89"
   version = "v2.6.2"
 
 [[projects]]
   name = "github.com/docker/docker"
-  packages = ["api/types","api/types/blkiodev","api/types/container","api/types/events","api/types/filters","api/types/mount","api/types/network","api/types/reference","api/types/registry","api/types/strslice","api/types/swarm","api/types/time","api/types/versions","api/types/volume","client","pkg/tlsconfig"]
+  packages = [
+    "api/types",
+    "api/types/blkiodev",
+    "api/types/container",
+    "api/types/events",
+    "api/types/filters",
+    "api/types/mount",
+    "api/types/network",
+    "api/types/reference",
+    "api/types/registry",
+    "api/types/strslice",
+    "api/types/swarm",
+    "api/types/time",
+    "api/types/versions",
+    "api/types/volume",
+    "client",
+    "pkg/tlsconfig"
+  ]
   revision = "092cba3727bb9b4a2f0e922cd6c0f93ea270e363"
   version = "v1.13.1"
 
 [[projects]]
   name = "github.com/docker/go-connections"
-  packages = ["nat","sockets","tlsconfig"]
+  packages = [
+    "nat",
+    "sockets",
+    "tlsconfig"
+  ]
   revision = "3ede32e2033de7505e6500d6c868c2b9ed9f169d"
   version = "v0.3.0"
 
 [[projects]]
   name = "github.com/docker/go-units"
   packages = ["."]
-  revision = "0dadbb0345b35ec7ef35e228dabb8de89a65bf52"
-  version = "v0.3.2"
+  revision = "47565b4f722fb6ceae66b95f853feed578a4a51c"
+  version = "v0.3.3"
 
 [[projects]]
   name = "github.com/go-ini/ini"
   packages = ["."]
-  revision = "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a"
-  version = "v1.32.0"
+  revision = "ace140f73450505f33e8b8418216792275ae82a7"
+  version = "v1.35.0"
 
 [[projects]]
   branch = "master"
@@ -91,10 +157,13 @@
   version = "v1.20.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/vishvananda/netlink"
-  packages = [".","nl"]
-  revision = "3ff4c2196115d804aa1c747781ad2b2a5c73e140"
+  packages = [
+    ".",
+    "nl"
+  ]
+  revision = "a2ad57a690f3caf3015351d2d6e1c0b95c349752"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -105,18 +174,26 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","proxy"]
-  revision = "d866cfc389cec985d6fda2859936a575a55a3ab6"
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "internal/socks",
+    "proxy"
+  ]
+  revision = "d41e8174641f662c5a2d1c7a5f9e828788eb8706"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
-  revision = "571f7bbbe08da2a8955aed9d4db316e78630e9a3"
+  packages = [
+    "unix",
+    "windows"
+  ]
+  revision = "3ccc7e5779793fd54564baf60c51bf017955e0ba"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a69f2c698ef5fbbfe3262e490eaead96a0c123cc5c77d6cbcecbdc971bceb672"
+  inputs-digest = "b9c07db25ce0338c3512b88729bf1b13670c051360a223c73bfe292e637625a7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -5,7 +5,7 @@
 
 [[constraint]]
   name = "github.com/containernetworking/plugins"
-  version = "~0.6.0"
+  version = "~0.7.1"
 
 [[constraint]]
   name = "github.com/docker/docker"
@@ -18,7 +18,3 @@
 [[constraint]]
   name = "github.com/urfave/cli"
   version = "~1.20.0"
-
-[[constraint]]
-  name = "github.com/go-ini/ini"
-  version = "1.30.3"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Kubernetes limit of 110 pods per instance.
 
 ## Features
 
-* Designed and tested on Kubernetes in AWS (v1.8 with CRI-O)
+* Designed and tested on Kubernetes in AWS (v1.10 with CRI-O and Docker)
 * No overlay network; very low overhead with IPvlan
 * No external or local network services required outside of the AWS
   EC2 API; host-local scale up and scale down of network resources
@@ -128,6 +128,14 @@ traffic is the right future direction.
 
 # Using with Kubernetes
 
+## Supported container runtimes
+
+`cni-ipvlan-vpc-k8s` is used in production at Lyft with cri-o for
+non-GPU workloads and Docker w/ nvidia-docker for GPU workloads.
+
+Note that for cri-o, `manage_network_ns_lifecycle` *must* be set to
+true.
+
 ## Prerequisites
 
 1. By default, we use a secondary (and tertiary, ...) ENI adapter for
@@ -138,16 +146,17 @@ traffic is the right future direction.
    http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html
    Most hosts support > 1 adapter, except for some of the smallest
    hardware types.
-1. AWS VPC with a minimum number of subnets equal to the maximum
-   number of attached ENIs. In the normal case of supporting up to the
-   default 110 Pods per instance, you'll want five subnets (one for
-   the control plane on the boot ENI and four subnets for the Pod
-   ENIs). The example configuration uses adapter index 1 onward for
-   Pods. We recommend creating a secondary IPv4 CIDR block for
+1. AWS VPC with a recommended minimum number of subnets equal to the
+   maximum number of attached ENIs. In the normal case of supporting
+   up to the default 110 Pods per instance, you'll want five subnets
+   (one for the control plane on the boot ENI and four subnets for the
+   Pod ENIs). The example configuration uses adapter index 1 onward
+   for Pods. We recommend creating a secondary IPv4 CIDR block for
    Kubernetes deployments within existing VPCs and subnet
    appropriately for the number of ENIs.  In our primary region, we
    divide up our secondary IPv4 CIDR (/16) into 5 /20s per AZ with 3
-   AZs.
+   AZs. Datadog has provided code which removes the restriction on one
+   subnet per ENI; however, we've yet to test it thoroughly at Lyft.
 1. (Optional) AWS subnets tagged if you want to limit which ones can
    be used.
 1. The `kubelet` process _must_ be started with the `--node-ip` option
@@ -190,12 +199,11 @@ pinch, you may `go get -u github.com/golang/dep/cmd/dep`.
 
 ## Example Configuration
 
-This example CNI conflist uses the bundled modified
-`cni-ipvlan-vpc-k8s-ipvlan` plugin to create Pod IPs on the secondary
-and above ENI adapters and chains with the
-`cni-ipvlan-vpc-k8s-unnumbered-ptp` plugin to create unnumbered
-point-to-point links back to the default namespace from each Pod. New
-interfaces will be attached to subnets tagged with
+This example CNI conflist creates Pod IPs on the secondary and above
+ENI adapters and chains with the upstream ipvlan plugin (0.7.0 or
+later required) and the `cni-ipvlan-vpc-k8s-unnumbered-ptp` plugin to
+create unnumbered point-to-point links back to the default namespace
+from each Pod. New interfaces will be attached to subnets tagged with
 `kubernetes_kubelet` = `true`, and created with the defined security
 groups.
 
@@ -207,40 +215,41 @@ not a dependency of this software.
 
 ```
 {
-  "cniVersion": "0.3.1",
-  "name": "cni-ipvlan-vpc-k8s",
-  "plugins": [
-  {
-      "cniVersion": "0.3.1",
-      "type": "cni-ipvlan-vpc-k8s-ipvlan",
-      "mode": "l2",
-      "master": "ipam",
-      "ipam": {
-          "type": "cni-ipvlan-vpc-k8s-ipam",
-          "interfaceIndex": 1,
-	      "subnetTags": {
-	          "kubernetes_kubelet": "true"
-     	  },
-	      "secGroupIds": [
-	          "sg-1234",
-	          "sg-5678"
-	          ]
-          }
-    },
-    {
-        "cniVersion": "0.3.1",
-        "type": "cni-ipvlan-vpc-k8s-unnumbered-ptp",
-        "hostInterface": "eth0",
-        "containerInterface": "veth0",
-        "ipMasq": true
-    }
+    "cniVersion": "0.3.1",
+    "name": "cni-ipvlan-vpc-k8s",
+    "plugins": [
+	{
+	    "cniVersion": "0.3.1",
+	    "type": "cni-ipvlan-vpc-k8s-ipam",
+	    "interfaceIndex": 1,
+	    "subnetTags": {
+		"kubernetes_kubelet": "true"
+	    },
+	    "secGroupIds": [
+		"sg-1234",
+		"sg-5678"
+	    ]
+	},
+	{
+	    "cniVersion": "0.3.1",
+	    "type": "cni-ipvlan-vpc-k8s-ipvlan",
+	    "mode": "l2"
+	},
+	{
+	    "cniVersion": "0.3.1",
+	    "type": "cni-ipvlan-vpc-k8s-unnumbered-ptp",
+	    "hostInterface": "eth0",
+	    "containerInterface": "veth0",
+	    "ipMasq": true
+	}
     ]
 }
 ```
 
-### Other IPAM configuration flags
+### Other configuration flags
 
-In the above `ipam` block, several options are available:
+In the above `cni-ipvlan-vpc-k8s-ipam` config, several options are
+available:
 
  - `interfaceIndex`: We also recommend never using the boot ENI
    adapter with this plugin (though it is possible). By setting
@@ -264,7 +273,49 @@ In the above `ipam` block, several options are available:
    plugin will make a (cached) call to `DescribeVpcPeeringConnections`
    to enumerate all peered VPCs. Routes will be added so connections
    to these VPCs will be sourced from the IPvlan adapter in the pod
-   and not through the host masquerade. 
+   and not through the host masquerade.
+- `reuseIPWait`: Seconds to wait before free IP addresses are made
+   available for reuse by Pods. Defaults to 60 seconds. `reuseIPWait`
+   functions as both a lock to prevent addresses from being grabbed by
+   Pods spinning up in between the stages of chained CNI plugin
+   execution and as a method of delaying when a new Pod can grab the
+   same IP address of a terminating Pod.
+
+
+### IP address lifecycle management
+
+As new Pods are created, if needed, secondary IP addresses are added
+to secondary ENI adapters until they reach capacity. A lightweight
+file-based registry stores hints containing free IP addresses
+available to the instance to prevent unnecessary churn from adding and
+removing IPs to and from ENI adapters, which is a fairly heavyweight
+AWS process. By default, free IP addresses are made available for
+reuse by Pods after being unused for at least 60 seconds. To handle
+cases where IPs are not frequently reused by Pods, and an excess of
+free IP addresses becomes available on an instance, a systemd timer is
+recommended to garbage collect these old IPs.
+
+Sample cni-gc.service:
+```[Unit]
+Description=Garbage collect IPs unused for 15 minutes
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/cni-ipvlan-vpc-k8s-tool registry-gc --free-after=15m
+```
+
+Sample cni-gc.timer:
+```
+[Unit]
+Description=Run cni-gc every 5 minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=5min
+
+[Install]
+WantedBy=timers.target
+```
 
 ## The CLI Tool
 
@@ -285,19 +336,21 @@ options.
        v-next
 
     COMMANDS:
-         new-interface             Create a new interface
-         remove-interface          Remove an existing interface
-         deallocate                Deallocate a private IP
-         allocate-first-available  Allocate a private IP on the first available interface
-         free-ips                  List all currently unassigned AWS IP addresses
-         eniif                     List all ENI interfaces and their setup with addresses
-         addr                      List all bound IP addresses
-         subnets                   Show available subnets for this host
-         limits                    Display limits for ENI for this instance type
-         bugs                      Show any bugs associated with this instance
-         vpccidr                   Show the VPC CIDRs associated with current interfaces
-         vpcpeercidr               Show the peered VPC CIDRs associated with current interfaces
-         help, h                   Shows a list of commands or help for one command
+	 new-interface             Create a new interface
+	 remove-interface          Remove an existing interface
+	 deallocate                Deallocate a private IP
+	 allocate-first-available  Allocate a private IP on the first available interface
+	 free-ips                  List all currently unassigned AWS IP addresses
+	 eniif                     List all ENI interfaces and their setup with addresses
+	 addr                      List all bound IP addresses
+	 subnets                   Show available subnets for this host
+	 limits                    Display limits for ENI for this instance type
+	 bugs                      Show any bugs associated with this instance
+	 vpccidr                   Show the VPC CIDRs associated with current interfaces
+	 vpcpeercidr               Show the peered VPC CIDRs associated with current interfaces
+	 registry-list             List all known free IPs in the internal registry
+	 registry-gc               Free all IPs that have remained unused for a given time interval
+	 help, h                   Shows a list of commands or help for one command
 
     GLOBAL OPTIONS:
        --help, -h     show help

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Kubernetes limit of 110 pods per instance.
 
 ## Features
 
-* Designed and tested on Kubernetes in AWS (v1.10 with CRI-O and Docker)
+* Designed and tested on Kubernetes in AWS (v1.10 with cri-o, docker, and containerd)
 * No overlay network; very low overhead with IPvlan
 * No external or local network services required outside of the AWS
   EC2 API; host-local scale up and scale down of network resources

--- a/aws/allocate.go
+++ b/aws/allocate.go
@@ -44,6 +44,7 @@ func (c *allocateClient) AllocateIPOn(intf Interface) (*AllocationResult, error)
 		return nil, err
 	}
 
+	registry := &Registry{}
 	for attempts := 10; attempts > 0; attempts-- {
 		newIntf, err := c.aws.getInterface(intf.Mac)
 		if err != nil {
@@ -61,11 +62,15 @@ func (c *allocateClient) AllocateIPOn(intf Interface) (*AllocationResult, error)
 					}
 				}
 				if !found {
-					// New IP
-					return &AllocationResult{
-						&newip,
-						newIntf,
-					}, nil
+					// only return IPs that haven't been previously registered
+					if exists, err := registry.HasIP(newip); err == nil && !exists {
+						// New IP. Timestamp the addition as a free IP.
+						registry.TrackIP(newip)
+						return &AllocationResult{
+							&newip,
+							newIntf,
+						}, nil
+					}
 				}
 			}
 		}

--- a/aws/interface.go
+++ b/aws/interface.go
@@ -108,9 +108,11 @@ func (c *interfaceClient) NewInterfaceOnSubnetAtIndex(index int, secGrps []strin
 		}
 		for _, intf := range newInterfaces {
 			if intf.Mac == *resp.NetworkInterface.MacAddress {
-				// New IP. Timestamp the addition as a free IP.
-				registry := &Registry{}
-				registry.TrackIP(net.ParseIP(*resp.NetworkInterface.PrivateIpAddress))
+				if privateIpAddr := net.ParseIP(*resp.NetworkInterface.PrivateIpAddress); privateIpAddr != nil {
+					// New IP. Timestamp the addition as a free IP.
+					registry := &Registry{}
+					registry.TrackIP(privateIpAddr)
+				}
 				configureInterface(&intf)
 				return &intf, nil
 			}

--- a/aws/interface.go
+++ b/aws/interface.go
@@ -108,10 +108,10 @@ func (c *interfaceClient) NewInterfaceOnSubnetAtIndex(index int, secGrps []strin
 		}
 		for _, intf := range newInterfaces {
 			if intf.Mac == *resp.NetworkInterface.MacAddress {
-				if privateIpAddr := net.ParseIP(*resp.NetworkInterface.PrivateIpAddress); privateIpAddr != nil {
+				if privateIPAddr := net.ParseIP(*resp.NetworkInterface.PrivateIpAddress); privateIPAddr != nil {
 					// New IP. Timestamp the addition as a free IP.
 					registry := &Registry{}
-					registry.TrackIP(privateIpAddr)
+					registry.TrackIP(privateIPAddr)
 				}
 				configureInterface(&intf)
 				return &intf, nil

--- a/aws/interface.go
+++ b/aws/interface.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"sort"
 	"time"
@@ -107,6 +108,9 @@ func (c *interfaceClient) NewInterfaceOnSubnetAtIndex(index int, secGrps []strin
 		}
 		for _, intf := range newInterfaces {
 			if intf.Mac == *resp.NetworkInterface.MacAddress {
+				// New IP. Timestamp the addition as a free IP.
+				registry := &Registry{}
+				registry.TrackIP(net.ParseIP(*resp.NetworkInterface.PrivateIpAddress))
 				configureInterface(&intf)
 				return &intf, nil
 			}

--- a/aws/registry_test.go
+++ b/aws/registry_test.go
@@ -1,4 +1,4 @@
-package registry
+package aws
 
 import (
 	"net"

--- a/plugin/ipvlan/ipvlan.go
+++ b/plugin/ipvlan/ipvlan.go
@@ -30,6 +30,7 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+// NetConf contains network configuration parameters
 type NetConf struct {
 	types.NetConf
 

--- a/plugin/ipvlan/ipvlan.go
+++ b/plugin/ipvlan/ipvlan.go
@@ -30,13 +30,23 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-// NetConf contains network configuration parameters
 type NetConf struct {
 	types.NetConf
+
+	// support chaining for master interface and IP decisions
+	// occurring prior to running ipvlan plugin
+	RawPrevResult *map[string]interface{} `json:"prevResult"`
+	PrevResult    *current.Result         `json:"-"`
+
 	Master string `json:"master"`
 	Mode   string `json:"mode"`
 	MTU    int    `json:"mtu"`
 }
+
+const (
+	cniAdd = iota
+	cniDel
+)
 
 func init() {
 	// this ensures that main runs only on main thread (thread group leader).
@@ -45,13 +55,36 @@ func init() {
 	runtime.LockOSThread()
 }
 
-func loadConf(bytes []byte) (*NetConf, string, error) {
+func loadConf(bytes []byte, cmd int) (*NetConf, string, error) {
 	n := &NetConf{}
 	if err := json.Unmarshal(bytes, n); err != nil {
 		return nil, "", fmt.Errorf("failed to load netconf: %v", err)
 	}
-	if n.Master == "" {
-		return nil, "", fmt.Errorf(`"master" field is required. It specifies the host interface name to virtualize`)
+	// Parse previous result
+	if n.RawPrevResult != nil {
+		resultBytes, err := json.Marshal(n.RawPrevResult)
+		if err != nil {
+			return nil, "", fmt.Errorf("could not serialize prevResult: %v", err)
+		}
+		res, err := version.NewResult(n.CNIVersion, resultBytes)
+		if err != nil {
+			return nil, "", fmt.Errorf("could not parse prevResult: %v", err)
+		}
+		n.RawPrevResult = nil
+		n.PrevResult, err = current.NewResultFromResult(res)
+		if err != nil {
+			return nil, "", fmt.Errorf("could not convert result to current version: %v", err)
+		}
+	}
+	if n.Master == "" && cmd != cniDel {
+		if n.PrevResult == nil {
+			return nil, "", fmt.Errorf(`"master" field is required. It specifies the host interface name to virtualize`)
+		}
+		if len(n.PrevResult.Interfaces) == 1 && n.PrevResult.Interfaces[0].Name != "" {
+			n.Master = n.PrevResult.Interfaces[0].Name
+		} else {
+			return nil, "", fmt.Errorf("chained master failure. PrevResult lacks a single named interface")
+		}
 	}
 	return n, n.CNIVersion, nil
 }
@@ -128,7 +161,7 @@ func createIpvlan(conf *NetConf, ifName string, netns ns.NetNS) (*current.Interf
 }
 
 func cmdAdd(args *skel.CmdArgs) error {
-	n, cniVersion, err := loadConf(args.StdinData)
+	n, cniVersion, err := loadConf(args.StdinData, cniAdd)
 	if err != nil {
 		return err
 	}
@@ -139,35 +172,32 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 	defer netns.Close()
 
-	// run the IPAM plugin and get back the config to apply
-	r, err := ipam.ExecAdd(n.IPAM.Type, args.StdinData)
-	if err != nil {
-		return err
-	}
-	// Convert whatever the IPAM result was into the current Result type
-	result, err := current.NewResultFromResult(r)
-	if err != nil {
-		return err
-	}
-
-	if len(result.IPs) == 0 {
-		return errors.New("IPAM plugin returned missing IP config")
-	}
-
-	if n.Master == "ipam" {
-		// Use an IPAM supplied master interface
-		if len(result.Interfaces) == 1 && result.Interfaces[0].Name != "" {
-			n.Master = result.Interfaces[0].Name
-		} else {
-			return errors.New("IPAM plugin returned missing master interface")
-		}
-	}
-
 	ipvlanInterface, err := createIpvlan(n, args.IfName, netns)
 	if err != nil {
 		return err
 	}
 
+	var result *current.Result
+	// Configure iface from PrevResult if we have IPs and an IPAM
+	// block has not been configured
+	if n.IPAM.Type == "" && n.PrevResult != nil && len(n.PrevResult.IPs) > 0 {
+		result = n.PrevResult
+	} else {
+		// run the IPAM plugin and get back the config to apply
+		r, err := ipam.ExecAdd(n.IPAM.Type, args.StdinData)
+		if err != nil {
+			return err
+		}
+		// Convert whatever the IPAM result was into the current Result type
+		result, err = current.NewResultFromResult(r)
+		if err != nil {
+			return err
+		}
+
+		if len(result.IPs) == 0 {
+			return errors.New("IPAM plugin returned missing IP config")
+		}
+	}
 	for _, ipc := range result.IPs {
 		// All addresses belong to the ipvlan interface
 		ipc.Interface = current.Int(0)
@@ -188,14 +218,22 @@ func cmdAdd(args *skel.CmdArgs) error {
 }
 
 func cmdDel(args *skel.CmdArgs) error {
-	n, _, err := loadConf(args.StdinData)
+	n, _, err := loadConf(args.StdinData, cniDel)
 	if err != nil {
 		return err
 	}
 
-	err = ipam.ExecDel(n.IPAM.Type, args.StdinData)
-	if err != nil {
-		return err
+	// On chained invocation, IPAM block can be empty
+	if n.IPAM.Type != "" {
+		err = ipam.ExecDel(n.IPAM.Type, args.StdinData)
+		if err != nil {
+			return err
+		}
+	}
+
+	// On chained invocation, Master can be empty
+	if n.Master == "" {
+		return nil
 	}
 
 	if args.Netns == "" {


### PR DESCRIPTION
* Move to CNI chaining mechanism as agreed upon in https://github.com/containernetworking/plugins/pull/88. One minor change is still needed to the upstream ipvlan plugin, so that plugin remains forked -- will work to upstream the fix. All installs need to move to the new plugin chained format, as this change breaks compatibility with the old cni-ipvlan-vpc-k8s configuration format.
* Add `reuseIPWait` as a mechanism to lock IP addresses between chained plugin execution and default to 60 seconds.
* Move registry to `/run` (tmpfs backed).
