### PR TITLE
Do not cache subnet results if subnets returns error

### DIFF
--- a/aws/client.go
+++ b/aws/client.go
@@ -49,7 +49,7 @@ func init() {
 	awsClient := &awsclient{}
 	subnets := &subnetsCacheClient{
 		&subnetsClient{aws: awsClient},
-		1 * time.Minute,
+		5 * time.Minute,
 	}
 	defaultClient = &combinedClient{
 		subnets,

--- a/aws/subnets.go
+++ b/aws/subnets.go
@@ -44,7 +44,9 @@ func (s *subnetsCacheClient) GetSubnetsForInstance() (subnets []Subnet, err erro
 		return
 	}
 	subnets, err = s.subnets.GetSubnetsForInstance()
-	cache.Store("subnets_for_instance", s.expiration, &subnets)
+	if err == nil {
+		cache.Store("subnets_for_instance", s.expiration, &subnets)
+	}
 	return
 }
 


### PR DESCRIPTION
This change makes a quick fix to not cache a nil subnet response if
the subnet API call has failed.