### PR TITLE
Add defaultRouteToVpc and extraContainerRoutes opt

### DIFF
--- a/plugin/unnumbered-ptp/unnumbered-ptp.go
+++ b/plugin/unnumbered-ptp/unnumbered-ptp.go
@@ -67,11 +67,13 @@ type PluginConf struct {
 	RawPrevResult *map[string]interface{} `json:"prevResult"`
 	PrevResult    *current.Result         `json:"-"`
 
-	IPMasq             bool   `json:"ipMasq"`
-	HostInterface      string `json:"hostInterface"`
-	ContainerInterface string `json:"containerInterface"`
-	MTU                int    `json:"mtu"`
-	TableStart         int    `json:"routeTableStart"`
+	IPMasq               bool     `json:"ipMasq"`
+	HostInterface        string   `json:"hostInterface"`
+	ContainerInterface   string   `json:"containerInterface"`
+	MTU                  int      `json:"mtu"`
+	TableStart           int      `json:"routeTableStart"`
+	DefaultRouteToVPC    bool     `json:"defaultRouteToVpc"`
+	ExtraContainerRoutes []string `json:"extraContainerRoutes"`
 }
 
 // parseConfig parses the supplied configuration (and prevResult) from stdin.
@@ -164,7 +166,7 @@ func findFreeTable(start int) (int, error) {
 	return -1, fmt.Errorf("failed to find free route table")
 }
 
-func addPolicyRules(veth *net.Interface, ipc *current.IPConfig, routes []*types.Route, tableStart int) error {
+func addPolicyRules(veth *net.Interface, ipc *current.IPConfig, routes []*types.Route, tableStart int, defaultRouteToVpc bool, netns ns.NetNS, hostIfName string) error {
 	table := -1
 
 	// depend on netlink atomicity to win races for table slots on initial route add
@@ -218,10 +220,32 @@ func addPolicyRules(veth *net.Interface, ipc *current.IPConfig, routes []*types.
 		return fmt.Errorf("failed to add policy rule %v: %v", rule, err)
 	}
 
+	if defaultRouteToVpc {
+		err = netns.Do(func(_ ns.NetNS) error {
+			hostIf, err := net.InterfaceByName(hostIfName)
+			if err != nil {
+				return fmt.Errorf("failed to look up %q: %v", hostIfName, err)
+			}
+			err = netlink.RouteAdd(&netlink.Route{
+				LinkIndex: hostIf.Index,
+				Dst:       nil,
+				Gw:        routes[0].GW,
+				Scope:     netlink.SCOPE_UNIVERSE,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to add default route via %v: %v", routes[0].GW, err)
+			}
+			return nil
+		})
+	}
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
-func setupContainerVeth(netns ns.NetNS, ifName string, mtu int, hostAddrs []netlink.Addr, masq, containerIPV4, containerIPV6 bool, k8sIfName string, pr *current.Result) (*current.Interface, *current.Interface, error) {
+func setupContainerVeth(netns ns.NetNS, ifName string, mtu int, hostAddrs []netlink.Addr, masq, containerIPV4, containerIPV6 bool, k8sIfName string, defaultRouteToVpc bool, extraContainerRoutes []string, pr *current.Result) (*current.Interface, *current.Interface, error) {
 	hostInterface := &current.Interface{}
 	containerInterface := &current.Interface{}
 
@@ -279,15 +303,33 @@ func setupContainerVeth(netns ns.NetNS, ifName string, mtu int, hostAddrs []netl
 			}
 		}
 
+		for _, route := range extraContainerRoutes {
+			_, dstNet, err := net.ParseCIDR(route)
+			if err != nil {
+				return fmt.Errorf("failed to add extra container route: %v", err)
+			}
+			err = netlink.RouteAdd(&netlink.Route{
+				LinkIndex: contVeth.Index,
+				Scope:     netlink.SCOPE_LINK,
+				Dst:       dstNet,
+			})
+
+			if err != nil {
+				return fmt.Errorf("failed to add host route dst %v: %v", dstNet, err)
+			}
+
+		}
 		// add a default gateway pointed at the first hostAddr
-		err = netlink.RouteAdd(&netlink.Route{
-			LinkIndex: contVeth.Index,
-			Scope:     netlink.SCOPE_UNIVERSE,
-			Dst:       nil,
-			Gw:        hostAddrs[0].IP,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to add default route %v: %v", hostAddrs[0].IP, err)
+		if !defaultRouteToVpc {
+			err = netlink.RouteAdd(&netlink.Route{
+				LinkIndex: contVeth.Index,
+				Scope:     netlink.SCOPE_UNIVERSE,
+				Dst:       nil,
+				Gw:        hostAddrs[0].IP,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to add default route %v: %v", hostAddrs[0].IP, err)
+			}
 		}
 
 		// Send a gratuitous arp for all borrowed v4 addresses
@@ -305,7 +347,7 @@ func setupContainerVeth(netns ns.NetNS, ifName string, mtu int, hostAddrs []netl
 	return hostInterface, containerInterface, nil
 }
 
-func setupHostVeth(vethName string, hostAddrs []netlink.Addr, masq bool, tableStart int, result *current.Result) error {
+func setupHostVeth(vethName string, hostAddrs []netlink.Addr, masq bool, tableStart int, defaultRouteToVpc bool, netns ns.NetNS, hostIfName string, result *current.Result) error {
 	// no IPs to route
 	if len(result.IPs) == 0 {
 		return nil
@@ -339,7 +381,7 @@ func setupHostVeth(vethName string, hostAddrs []netlink.Addr, masq bool, tableSt
 	}
 
 	// add policy rules for traffic coming in from Pods and destined for the VPC
-	err = addPolicyRules(veth, result.IPs[0], result.Routes, tableStart)
+	err = addPolicyRules(veth, result.IPs[0], result.Routes, tableStart, defaultRouteToVpc, netns, hostIfName)
 	if err != nil {
 		return fmt.Errorf("failed to add policy rules: %v", err)
 	}
@@ -419,12 +461,12 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 
 	hostInterface, _, err := setupContainerVeth(netns, conf.ContainerInterface, conf.MTU,
-		hostAddrs, conf.IPMasq, containerIPV4, containerIPV6, args.IfName, conf.PrevResult)
+		hostAddrs, conf.IPMasq, containerIPV4, containerIPV6, args.IfName, conf.DefaultRouteToVPC, conf.ExtraContainerRoutes, conf.PrevResult)
 	if err != nil {
 		return err
 	}
 
-	if err = setupHostVeth(hostInterface.Name, hostAddrs, conf.IPMasq, conf.TableStart, conf.PrevResult); err != nil {
+	if err = setupHostVeth(hostInterface.Name, hostAddrs, conf.IPMasq, conf.TableStart, conf.DefaultRouteToVPC, netns, conf.HostInterface, conf.PrevResult); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
* defaultRouteToVpc allows you to set the default route in the container
namespace to the VPC router. This is useful for AWS networks that
*don't* assign public IPs to their instances and rely on NAT boxes
listed in the VPC route table. Or if you happen to have other networks
reachable from the VPC route table.

* extraContainerRoutes allows you to add extra routes in the container
that route back to the host via the veth pair. This is useful if you
have things listening on the host namespace but have updated the default
route to go via the VPC router (as above).