### PR TITLE
[README] Change example containerInterface for cadvisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ not a dependency of this software.
 	    "cniVersion": "0.3.1",
 	    "type": "cni-ipvlan-vpc-k8s-unnumbered-ptp",
 	    "hostInterface": "eth0",
-	    "containerInterface": "veth0",
+	    "containerInterface": "eth1",
 	    "ipMasq": true
 	}
     ]


### PR DESCRIPTION
cadvisor ignores interfaces prefixed with `veth` which means the kubelet network metrics do not include the interface to the host and are incomplete:
https://github.com/google/cadvisor/blob/master/container/libcontainer/handler.go#L236-L247

Solving this is easy and simply involve changing the containerInterface name. I think most users of the plugin start with the configuration example from the README (we certainly did) so having a name that works with cadvisor there makes sense.