### PR TITLE
IP batching

### DIFF
--- a/aws/allocate.go
+++ b/aws/allocate.go
@@ -28,7 +28,7 @@ type allocateClient struct {
 	subnet SubnetsClient
 }
 
-// AllocateIPOn allocates an IP on a specific interface.
+// AllocateIPsOn allocates IPs on a specific interface.
 func (c *allocateClient) AllocateIPsOn(intf Interface, batchSize int64) ([]*AllocationResult, error) {
 	var allocationResults []*AllocationResult
 	client, err := c.aws.newEC2()
@@ -76,8 +76,9 @@ func (c *allocateClient) AllocateIPsOn(intf Interface, batchSize int64) ([]*Allo
 					if exists, err := registry.HasIP(newip); err == nil && !exists {
 						// New IP. Timestamp the addition as a free IP.
 						registry.TrackIP(newip)
+						ipcopy := newip // Need to copy
 						allocationResult := &AllocationResult{
-							&newip,
+							&ipcopy,
 							newIntf,
 						}
 						allocationResults = append(allocationResults, allocationResult)
@@ -94,8 +95,8 @@ func (c *allocateClient) AllocateIPsOn(intf Interface, batchSize int64) ([]*Allo
 	return nil, fmt.Errorf("Can't locate new IP address from AWS")
 }
 
-// AllocateIPFirstAvailableAtIndex allocates an IP address, skipping any adapter < the given index
-// Returns a reference to the interface the IP was allocated on
+// AllocateIPsFirstAvailableAtIndex allocates IP addresses, skipping any adapter < the given index
+// Returns a reference to the interface the IPs were allocated on
 func (c *allocateClient) AllocateIPsFirstAvailableAtIndex(index int, batchSize int64) ([]*AllocationResult, error) {
 	interfaces, err := c.aws.GetInterfaces()
 	if err != nil {
@@ -133,8 +134,8 @@ func (c *allocateClient) AllocateIPsFirstAvailableAtIndex(index int, batchSize i
 	return nil, fmt.Errorf("Unable to allocate - no IPs available on any interfaces")
 }
 
-// AllocateIPFirstAvailable allocates an IP address on the first available IP address
-// Returns a reference to the interface the IP was allocated on
+// AllocateIPsFirstAvailable allocates IP addresses on the first available IP address
+// Returns a reference to the interface the IPs were allocated on
 func (c *allocateClient) AllocateIPsFirstAvailable(batchSize int64) ([]*AllocationResult, error) {
 	return c.AllocateIPsFirstAvailableAtIndex(0, batchSize)
 }

--- a/aws/allocate.go
+++ b/aws/allocate.go
@@ -17,9 +17,9 @@ type AllocationResult struct {
 
 // AllocateClient offers IP allocation on interfaces
 type AllocateClient interface {
-	AllocateIPOn(intf Interface) (*AllocationResult, error)
-	AllocateIPFirstAvailableAtIndex(index int) (*AllocationResult, error)
-	AllocateIPFirstAvailable() (*AllocationResult, error)
+	AllocateIPsOn(intf Interface, batchSize int64) (*AllocationResult, error)
+	AllocateIPsFirstAvailableAtIndex(index int, batchSize int64) (*AllocationResult, error)
+	AllocateIPsFirstAvailable(batchSize int64) (*AllocationResult, error)
 	DeallocateIP(ipToRelease *net.IP) error
 }
 
@@ -29,7 +29,7 @@ type allocateClient struct {
 }
 
 // AllocateIPOn allocates an IP on a specific interface.
-func (c *allocateClient) AllocateIPOn(intf Interface) (*AllocationResult, error) {
+func (c *allocateClient) AllocateIPsOn(intf Interface, batchSize int64) (*AllocationResult, error) {
 	client, err := c.aws.newEC2()
 	if err != nil {
 		return nil, err
@@ -37,7 +37,16 @@ func (c *allocateClient) AllocateIPOn(intf Interface) (*AllocationResult, error)
 	request := ec2.AssignPrivateIpAddressesInput{
 		NetworkInterfaceId: &intf.ID,
 	}
-	request.SetSecondaryPrivateIpAddressCount(1)
+
+	available := int64(c.aws.ENILimits().IPv4 - len(intf.IPv4s))
+
+	// If there are fewer IPs left than the batch size, request all the remaining IPs
+	// batch size 0 conventionally means "request the limit"
+	if batchSize == 0 || available < batchSize {
+		batchSize = available
+	}
+
+	request.SetSecondaryPrivateIpAddressCount(batchSize)
 
 	_, err = client.AssignPrivateIpAddresses(&request)
 	if err != nil {
@@ -53,6 +62,7 @@ func (c *allocateClient) AllocateIPOn(intf Interface) (*AllocationResult, error)
 		}
 
 		if len(newIntf.IPv4s) != len(intf.IPv4s) {
+			var retIP *net.IP
 			// New address detected
 			for _, newip := range newIntf.IPv4s {
 				found := false
@@ -66,12 +76,15 @@ func (c *allocateClient) AllocateIPOn(intf Interface) (*AllocationResult, error)
 					if exists, err := registry.HasIP(newip); err == nil && !exists {
 						// New IP. Timestamp the addition as a free IP.
 						registry.TrackIP(newip)
-						return &AllocationResult{
-							&newip,
-							newIntf,
-						}, nil
+						retIP = &newip
 					}
 				}
+			}
+			if retIP != nil {
+				return &AllocationResult{
+					retIP,
+					newIntf,
+				}, nil
 			}
 		}
 		time.Sleep(1.0 * time.Second)
@@ -82,7 +95,7 @@ func (c *allocateClient) AllocateIPOn(intf Interface) (*AllocationResult, error)
 
 // AllocateIPFirstAvailableAtIndex allocates an IP address, skipping any adapter < the given index
 // Returns a reference to the interface the IP was allocated on
-func (c *allocateClient) AllocateIPFirstAvailableAtIndex(index int) (*AllocationResult, error) {
+func (c *allocateClient) AllocateIPsFirstAvailableAtIndex(index int, batchSize int64) (*AllocationResult, error) {
 	interfaces, err := c.aws.GetInterfaces()
 	if err != nil {
 		return nil, err
@@ -111,7 +124,7 @@ func (c *allocateClient) AllocateIPFirstAvailableAtIndex(index int) (*Allocation
 		}
 		for _, intf := range candidates {
 			if intf.SubnetID == subnet.ID {
-				return c.AllocateIPOn(intf)
+				return c.AllocateIPsOn(intf, batchSize)
 			}
 		}
 	}
@@ -121,8 +134,8 @@ func (c *allocateClient) AllocateIPFirstAvailableAtIndex(index int) (*Allocation
 
 // AllocateIPFirstAvailable allocates an IP address on the first available IP address
 // Returns a reference to the interface the IP was allocated on
-func (c *allocateClient) AllocateIPFirstAvailable() (*AllocationResult, error) {
-	return c.AllocateIPFirstAvailableAtIndex(0)
+func (c *allocateClient) AllocateIPsFirstAvailable(batchSize int64) (*AllocationResult, error) {
+	return c.AllocateIPsFirstAvailableAtIndex(0, batchSize)
 }
 
 // DeallocateIP releases an IP back to AWS

--- a/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
+++ b/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
@@ -55,7 +55,7 @@ func actionNewInterface(c *cli.Context) error {
 			fmt.Println("please specify security groups")
 			return fmt.Errorf("need security groups")
 		}
-		newIf, err := aws.DefaultClient.NewInterface(secGrps, filters)
+		newIf, err := aws.DefaultClient.NewInterface(secGrps, filters, 1)
 		if err != nil {
 			fmt.Println(err)
 			return err
@@ -125,7 +125,7 @@ func actionDeallocate(c *cli.Context) error {
 func actionAllocate(c *cli.Context) error {
 	return lib.LockfileRun(func() error {
 		index := c.Int("index")
-		res, err := aws.DefaultClient.AllocateIPFirstAvailableAtIndex(index)
+		res, err := aws.DefaultClient.AllocateIPsFirstAvailableAtIndex(index, 1)
 		if err != nil {
 			fmt.Println(err)
 			return err

--- a/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
+++ b/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
@@ -132,9 +132,10 @@ func actionAllocate(c *cli.Context) error {
 			fmt.Println(err)
 			return err
 		}
-		alloc := res[0]
+		for _, alloc := range res {
+			fmt.Printf("allocated %v on %v\n", alloc.IP, alloc.Interface.LocalName())
+		}
 
-		fmt.Printf("allocated %v on %v\n", alloc.IP, alloc.Interface.LocalName())
 		return nil
 
 	})

--- a/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
+++ b/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
@@ -130,8 +130,9 @@ func actionAllocate(c *cli.Context) error {
 			fmt.Println(err)
 			return err
 		}
+		alloc := res[0]
 
-		fmt.Printf("allocated %v on %v\n", res.IP, res.Interface.LocalName())
+		fmt.Printf("allocated %v on %v\n", alloc.IP, alloc.Interface.LocalName())
 		return nil
 
 	})

--- a/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
+++ b/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
@@ -48,6 +48,7 @@ func actionNewInterface(c *cli.Context) error {
 			fmt.Printf("Invalid filter specification %v", err)
 			return err
 		}
+		ipBatchSize := c.Int64("ip_batch_size")
 
 		secGrps := c.Args()
 
@@ -55,7 +56,7 @@ func actionNewInterface(c *cli.Context) error {
 			fmt.Println("please specify security groups")
 			return fmt.Errorf("need security groups")
 		}
-		newIf, err := aws.DefaultClient.NewInterface(secGrps, filters, 1)
+		newIf, err := aws.DefaultClient.NewInterface(secGrps, filters, ipBatchSize)
 		if err != nil {
 			fmt.Println(err)
 			return err
@@ -125,7 +126,8 @@ func actionDeallocate(c *cli.Context) error {
 func actionAllocate(c *cli.Context) error {
 	return lib.LockfileRun(func() error {
 		index := c.Int("index")
-		res, err := aws.DefaultClient.AllocateIPsFirstAvailableAtIndex(index, 1)
+		ipBatchSize := c.Int64("ip_batch_size")
+		res, err := aws.DefaultClient.AllocateIPsFirstAvailableAtIndex(index, ipBatchSize)
 		if err != nil {
 			fmt.Println(err)
 			return err
@@ -376,6 +378,10 @@ func main() {
 					Name:  "subnet_filter",
 					Usage: "Comma separated key=value filters to restrict subnets",
 				},
+				cli.Int64Flag{
+					Name:  "ip_batch_size",
+					Usage: "Number of ips to allocate on the interface",
+				},
 			},
 		},
 		{
@@ -395,7 +401,13 @@ func main() {
 			Usage:  "Allocate a private IP on the first available interface",
 			Action: actionAllocate,
 			Flags: []cli.Flag{
-				cli.IntFlag{Name: "index"},
+				cli.IntFlag{
+					Name: "index",
+				},
+				cli.Int64Flag{
+					Name:  "ip_batch_size",
+					Usage: "Number of ips to allocate on the interface",
+				},
 			},
 		},
 		{

--- a/plugin/ipam/main.go
+++ b/plugin/ipam/main.go
@@ -107,9 +107,11 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	// No free IPs available for use, so let's allocate one
 	if alloc == nil {
-		// allocate an IP on an available interface
-		alloc, err = aws.DefaultClient.AllocateIPsFirstAvailableAtIndex(conf.IfaceIndex, conf.IPBatchSize)
-		if err != nil {
+		// allocate IPs on an available interface
+		allocs, err := aws.DefaultClient.AllocateIPsFirstAvailableAtIndex(conf.IfaceIndex, conf.IPBatchSize)
+		if err == nil {
+			alloc = allocs[0]
+		} else {
 			// failed, so attempt to add an IP to a new interface
 			newIf, err := aws.DefaultClient.NewInterface(conf.SecGroupIds, conf.SubnetTags, conf.IPBatchSize)
 			if err != nil || len(newIf.IPv4s) < 1 {

--- a/plugin/ipam/main.go
+++ b/plugin/ipam/main.go
@@ -46,6 +46,7 @@ type PluginConf struct {
 	SkipDeallocation bool              `json:"skipDeallocation"`
 	RouteToVPCPeers  bool              `json:"routeToVpcPeers"`
 	ReuseIPWait      int               `json:"reuseIPWait"`
+	IPBatchSize      int64             `json:"ipBatchSize"`
 }
 
 func init() {
@@ -107,17 +108,15 @@ func cmdAdd(args *skel.CmdArgs) error {
 	// No free IPs available for use, so let's allocate one
 	if alloc == nil {
 		// allocate an IP on an available interface
-		alloc, err = aws.DefaultClient.AllocateIPFirstAvailableAtIndex(conf.IfaceIndex)
+		alloc, err = aws.DefaultClient.AllocateIPsFirstAvailableAtIndex(conf.IfaceIndex, conf.IPBatchSize)
 		if err != nil {
 			// failed, so attempt to add an IP to a new interface
-			newIf, err := aws.DefaultClient.NewInterface(conf.SecGroupIds, conf.SubnetTags)
-			// If this interface has somehow gained more than one IP since being allocated,
-			// abort this process and let a subsequent run find a valid IP.
-			if err != nil || len(newIf.IPv4s) != 1 {
+			newIf, err := aws.DefaultClient.NewInterface(conf.SecGroupIds, conf.SubnetTags, conf.IPBatchSize)
+			if err != nil || len(newIf.IPv4s) < 1 {
 				return fmt.Errorf("unable to create a new elastic network interface due to %v",
 					err)
 			}
-			// Freshly allocated interfaces will always have one valid IP - use
+			// Freshly allocated interfaces will always have at least one valid IP - use
 			// this IP address.
 			alloc = &aws.AllocationResult{
 				&newIf.IPv4s[0],


### PR DESCRIPTION
This PR adds a "ipBatchSize" config to the IPAM plugin.

When creating an interface or requesting additional IPs, the plugin will request the smaller of:

   - The configured 'batch size'
   - The number of remaining IPs allowed on the interface.

By convention, an ipBatchSize == 0 indicates that the user wants to allocate the max limit every time.