### PR TITLE
Inherit MTU from main interface

### DIFF
--- a/aws/interface.go
+++ b/aws/interface.go
@@ -113,7 +113,9 @@ func (c *interfaceClient) NewInterfaceOnSubnetAtIndex(index int, secGrps []strin
 					registry := &Registry{}
 					registry.TrackIP(privateIPAddr)
 				}
-				configureInterface(&intf)
+				// Interfaces are sorted by device number. The first one is the main one
+				mainIf := newInterfaces[0].IfName
+				configureInterface(&intf, mainIf)
 				return &intf, nil
 			}
 		}
@@ -124,7 +126,7 @@ func (c *interfaceClient) NewInterfaceOnSubnetAtIndex(index int, secGrps []strin
 }
 
 // Fire and forget method to configure an interface
-func configureInterface(intf *Interface) {
+func configureInterface(intf *Interface, mainIf string) {
 	// Found a match, going to try to make sure the interface is up
 	err := nl.UpInterfacePoll(intf.LocalName())
 	if err != nil {
@@ -133,7 +135,7 @@ func configureInterface(intf *Interface) {
 			intf.LocalName())
 		return
 	}
-	baseMtu, err := nl.GetMtu("eth0")
+	baseMtu, err := nl.GetMtu(mainIf)
 	if err != nil || baseMtu < 1000 || baseMtu > 9001 {
 		return
 	}

--- a/plugin/unnumbered-ptp/unnumbered-ptp.go
+++ b/plugin/unnumbered-ptp/unnumbered-ptp.go
@@ -12,7 +12,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 // This is a sample chained plugin that supports multiple CNI versions. It
 // parses prevResult according to the cniVersion
 package main
@@ -39,6 +38,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/utils/sysctl"
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/j-keck/arping"
+	"github.com/lyft/cni-ipvlan-vpc-k8s/nl"
 	"github.com/vishvananda/netlink"
 )
 
@@ -111,6 +111,15 @@ func parseConfig(stdin []byte) (*PluginConf, error) {
 
 	if conf.HostInterface == "" {
 		return nil, fmt.Errorf("hostInterface must be specified")
+	}
+
+	// If the MTU is not set, use the one of the hostInterface
+	if conf.MTU == 0 {
+		baseMtu, err := nl.GetMtu(conf.HostInterface)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get MTU for hostInterface")
+		}
+		conf.MTU = baseMtu
 	}
 
 	if conf.ContainerInterface == "" {


### PR DESCRIPTION
The MTU of secondary ENIs was based on interface `eth0` which does not exist on ubuntu instances.
This PR retrieves the name of the primary interface from the interface list instead.

In addition, when the MTU was not set in the PTP plugin, the veth was configured with the system defaults (usually 1500).
This PR instead defaults to the MTU of the hostInterface.

The goal is that all interfaces created by the plugins inherit the MTU from the main interface (to allow for jumbo frames in the VPC).

I think these defaults should work for all use cases, let me know what you think