### PR TITLE
Added extra routing CIDR option in IPAM plugin

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -246,6 +246,7 @@
     "github.com/containernetworking/plugins/pkg/ipam",
     "github.com/containernetworking/plugins/pkg/ns",
     "github.com/containernetworking/plugins/pkg/utils",
+    "github.com/containernetworking/plugins/pkg/utils/sysctl",
     "github.com/coreos/go-iptables/iptables",
     "github.com/docker/docker/api/types",
     "github.com/docker/docker/client",

--- a/plugin/ipam/main.go
+++ b/plugin/ipam/main.go
@@ -45,6 +45,7 @@ type PluginConf struct {
 	IfaceIndex       int               `json:"interfaceIndex"`
 	SkipDeallocation bool              `json:"skipDeallocation"`
 	RouteToVPCPeers  bool              `json:"routeToVpcPeers"`
+	ExtraRouteCIDR   []string          `json:"extraRouteCIDR"`
 	ReuseIPWait      int               `json:"reuseIPWait"`
 }
 
@@ -183,6 +184,14 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	// add routes for all VPC cidrs via the subnet gateway
 	for _, dst := range cidrs {
+		result.Routes = append(result.Routes, &types.Route{*dst, gw})
+	}
+
+	for _, dstStr := range conf.ExtraRouteCIDR {
+		_, dst, err := net.ParseCIDR(dstStr)
+		if err != nil {
+			return fmt.Errorf("unable to parse extra CIDRs: %s %v", dstStr, err)
+		}
 		result.Routes = append(result.Routes, &types.Route{*dst, gw})
 	}
 


### PR DESCRIPTION
This solves #67  

The issue was within the pod there was no route for the subnet outside VPC, but within AWS routing table associated with the subnet. Thus the pod had no idea how to route it and made a mess. 

Maybe the better option would be to ask the AWS API for the subnet routing table and learn the needed routes from there, though this is a quick fix for my use case. 