### PR TITLE
Use the AWS API to retrieve instance network limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ true.
         "ec2:DetachNetworkInterface"
         "ec2:DeleteNetworkInterface"
         "ec2:ModifyNetworkInterfaceAttribute"
+        "ec2:DescribeInstanceTypes"
         "ec2:DescribeVpcs"
         "ec2:DescribeVpcPeeringConnections"
 

--- a/aws/allocate.go
+++ b/aws/allocate.go
@@ -39,7 +39,7 @@ func (c *allocateClient) AllocateIPsOn(intf Interface, batchSize int64) ([]*Allo
 		NetworkInterfaceId: &intf.ID,
 	}
 
-	available := int64(c.aws.ENILimits().IPv4 - len(intf.IPv4s))
+	available := c.aws.ENILimits().IPv4 - int64(len(intf.IPv4s))
 
 	// If there are fewer IPs left than the batch size, request all the remaining IPs
 	// batch size 0 conventionally means "request the limit"
@@ -109,7 +109,7 @@ func (c *allocateClient) AllocateIPsFirstAvailableAtIndex(index int, batchSize i
 		if intf.Number < index {
 			continue
 		}
-		if len(intf.IPv4s) < limits.IPv4 {
+		if int64(len(intf.IPv4s)) < limits.IPv4 {
 			candidates = append(candidates, intf)
 		}
 	}

--- a/aws/allocate.go
+++ b/aws/allocate.go
@@ -39,7 +39,11 @@ func (c *allocateClient) AllocateIPsOn(intf Interface, batchSize int64) ([]*Allo
 		NetworkInterfaceId: &intf.ID,
 	}
 
-	available := c.aws.ENILimits().IPv4 - int64(len(intf.IPv4s))
+	limits, err := c.aws.ENILimits()
+	if err != nil {
+		return nil, err
+	}
+	available := limits.IPv4 - int64(len(intf.IPv4s))
 
 	// If there are fewer IPs left than the batch size, request all the remaining IPs
 	// batch size 0 conventionally means "request the limit"
@@ -102,7 +106,10 @@ func (c *allocateClient) AllocateIPsFirstAvailableAtIndex(index int, batchSize i
 	if err != nil {
 		return nil, err
 	}
-	limits := c.aws.ENILimits()
+	limits, err := c.aws.ENILimits()
+	if err != nil {
+		return nil, err
+	}
 
 	var candidates []Interface
 	for _, intf := range interfaces {

--- a/aws/interface.go
+++ b/aws/interface.go
@@ -167,7 +167,7 @@ func (c *interfaceClient) NewInterface(secGrps []string, requiredTags map[string
 	}
 
 	limits := c.aws.ENILimits()
-	if len(existingInterfaces) >= limits.Adapters {
+	if int64(len(existingInterfaces)) >= limits.Adapters {
 		return nil, fmt.Errorf("too many adapters on this instance already")
 	}
 

--- a/aws/interface.go
+++ b/aws/interface.go
@@ -57,7 +57,11 @@ func (c *interfaceClient) NewInterfaceOnSubnetAtIndex(index int, secGrps []strin
 	createReq.SetSubnetId(subnet.ID)
 
 	// Subtract 1 to Account for primary IP
-	ipv4Limit := int64(c.aws.ENILimits().IPv4) - 1
+	limits, err := c.aws.ENILimits()
+	if err != nil {
+		return nil, err
+	}
+	ipv4Limit := limits.IPv4 - 1
 
 	// batch size 0 conventionally means "request the limit"
 	if ipBatchSize == 0 || ipBatchSize > ipv4Limit {
@@ -166,7 +170,10 @@ func (c *interfaceClient) NewInterface(secGrps []string, requiredTags map[string
 		return nil, err
 	}
 
-	limits := c.aws.ENILimits()
+	limits, err := c.aws.ENILimits()
+	if err != nil {
+		return nil, err
+	}
 	if int64(len(existingInterfaces)) >= limits.Adapters {
 		return nil, fmt.Errorf("too many adapters on this instance already")
 	}

--- a/aws/limits.go
+++ b/aws/limits.go
@@ -1,10 +1,19 @@
 package aws
 
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/lyft/cni-ipvlan-vpc-k8s/aws/cache"
+)
+
 // ENILimit contains limits for adapter count and addresses
 type ENILimit struct {
-	Adapters int
-	IPv4     int
-	IPv6     int
+	Adapters int64
+	IPv4     int64
+	IPv6     int64
 }
 
 // LimitsClient provides methods for locating limits in AWS
@@ -12,271 +21,33 @@ type LimitsClient interface {
 	ENILimits() ENILimit
 }
 
-var eniLimits map[string]ENILimit
-
-func init() {
-	// This table of limits referenced from:
-	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html
-	eniLimits = map[string]ENILimit{
-		"a1.medium":     {2, 4, 4},
-		"a1.large":      {3, 10, 10},
-		"a1.xlarge":     {4, 15, 15},
-		"a1.2xlarge":    {4, 15, 15},
-		"a1.4xlarge":    {8, 30, 30},
-		"a1.metal":      {8, 30, 30},
-		"c1.medium":     {2, 6, 0},
-		"c1.xlarge":     {4, 15, 0},
-		"c3.large":      {3, 10, 10},
-		"c3.xlarge":     {4, 15, 15},
-		"c3.2xlarge":    {4, 15, 15},
-		"c3.4xlarge":    {8, 30, 30},
-		"c3.8xlarge":    {8, 30, 30},
-		"c4.large":      {3, 10, 10},
-		"c4.xlarge":     {4, 15, 15},
-		"c4.2xlarge":    {4, 15, 15},
-		"c4.4xlarge":    {8, 30, 30},
-		"c4.8xlarge":    {8, 30, 30},
-		"c5.large":      {3, 10, 10},
-		"c5.xlarge":     {4, 15, 15},
-		"c5.2xlarge":    {4, 15, 15},
-		"c5.4xlarge":    {8, 30, 30},
-		"c5.9xlarge":    {8, 30, 30},
-		"c5.12xlarge":   {8, 30, 30},
-		"c5.18xlarge":   {15, 50, 50},
-		"c5.24xlarge":   {15, 50, 50},
-		"c5.metal":      {15, 50, 50},
-		"c5d.large":     {3, 10, 10},
-		"c5d.xlarge":    {4, 15, 15},
-		"c5d.2xlarge":   {4, 15, 15},
-		"c5d.4xlarge":   {8, 30, 30},
-		"c5d.9xlarge":   {8, 30, 30},
-		"c5d.12xlarge":  {8, 30, 30},
-		"c5d.18xlarge":  {15, 50, 50},
-		"c5d.24xlarge":  {15, 50, 50},
-		"c5n.large":     {4, 15, 15},
-		"c5n.xlarge":    {4, 15, 15},
-		"c5n.2xlarge":   {4, 15, 15},
-		"c5n.4xlarge":   {8, 30, 30},
-		"c5n.9xlarge":   {8, 30, 30},
-		"c5n.18xlarge":  {15, 50, 50},
-		"cc2.8xlarge":   {8, 30, 0},
-		"cr1.8xlarge":   {8, 30, 0},
-		"d2.xlarge":     {4, 15, 15},
-		"d2.2xlarge":    {4, 15, 15},
-		"d2.4xlarge":    {8, 30, 30},
-		"d2.8xlarge":    {8, 30, 30},
-		"f1.2xlarge":    {4, 15, 15},
-		"f1.4xlarge":    {8, 30, 30},
-		"f1.16xlarge":   {8, 50, 50},
-		"g2.2xlarge":    {4, 15, 0},
-		"g2.8xlarge":    {8, 30, 0},
-		"g3s.xlarge":    {4, 15, 15},
-		"g3.4xlarge":    {8, 30, 30},
-		"g3.8xlarge":    {8, 30, 30},
-		"g3.16xlarge":   {15, 50, 50},
-		"h1.2xlarge":    {4, 15, 15},
-		"h1.4xlarge":    {8, 30, 30},
-		"h1.8xlarge":    {8, 30, 30},
-		"h1.16xlarge":   {15, 50, 50},
-		"hs1.8xlarge":   {8, 30, 0},
-		"i2.xlarge":     {4, 15, 15},
-		"i2.2xlarge":    {4, 15, 15},
-		"i2.4xlarge":    {8, 30, 30},
-		"i2.8xlarge":    {8, 30, 30},
-		"i3.large":      {3, 10, 10},
-		"i3.xlarge":     {4, 15, 15},
-		"i3.2xlarge":    {4, 15, 15},
-		"i3.4xlarge":    {8, 30, 30},
-		"i3.8xlarge":    {8, 30, 30},
-		"i3.16xlarge":   {15, 50, 50},
-		"i3.metal":      {15, 50, 50},
-		"i3en.large":    {3, 10, 10},
-		"i3en.xlarge":   {4, 15, 15},
-		"i3en.2xlarge":  {4, 15, 15},
-		"i3en.3xlarge":  {4, 15, 15},
-		"i3en.6xlarge":  {8, 30, 30},
-		"i3en.12xlarge": {8, 30, 30},
-		"i3en.24xlarge": {15, 50, 50},
-		"m1.small":      {2, 4, 0},
-		"m1.medium":     {2, 6, 0},
-		"m1.large":      {3, 10, 0},
-		"m1.xlarge":     {4, 15, 0},
-		"m2.xlarge":     {4, 15, 0},
-		"m2.2xlarge":    {4, 30, 0},
-		"m2.4xlarge":    {8, 30, 0},
-		"m3.medium":     {2, 6, 0},
-		"m3.large":      {3, 10, 0},
-		"m3.xlarge":     {4, 15, 0},
-		"m3.2xlarge":    {4, 30, 0},
-		"m4.large":      {2, 10, 10},
-		"m4.xlarge":     {4, 15, 15},
-		"m4.2xlarge":    {4, 15, 15},
-		"m4.4xlarge":    {8, 30, 30},
-		"m4.10xlarge":   {8, 30, 30},
-		"m4.16xlarge":   {8, 30, 30},
-		"m5.large":      {3, 10, 10},
-		"m5.xlarge":     {4, 15, 15},
-		"m5.2xlarge":    {4, 15, 15},
-		"m5.4xlarge":    {8, 30, 30},
-		"m5.12xlarge":   {8, 30, 30},
-		"m5.24xlarge":   {15, 50, 50},
-		"m5.metal":      {15, 50, 50},
-		"m5a.large":     {3, 10, 10},
-		"m5a.xlarge":    {4, 15, 15},
-		"m5a.2xlarge":   {4, 15, 15},
-		"m5a.4xlarge":   {8, 30, 30},
-		"m5a.12xlarge":  {8, 30, 30},
-		"m5a.24xlarge":  {15, 50, 50},
-		"m5ad.large":    {3, 10, 10},
-		"m5ad.xlarge":   {4, 15, 15},
-		"m5ad.2xlarge":  {4, 15, 15},
-		"m5ad.4xlarge":  {8, 30, 30},
-		"m5ad.12xlarge": {8, 30, 30},
-		"m5ad.24xlarge": {15, 50, 50},
-		"m5d.large":     {3, 10, 10},
-		"m5d.xlarge":    {4, 15, 15},
-		"m5d.2xlarge":   {4, 15, 15},
-		"m5d.4xlarge":   {8, 30, 30},
-		"m5d.12xlarge":  {8, 30, 30},
-		"m5d.24xlarge":  {15, 50, 50},
-		"m5d.metal":     {15, 50, 50},
-		"m5dn.large":    {3, 10, 10},
-		"m5dn.xlarge":   {4, 15, 15},
-		"m5dn.2xlarge":  {4, 15, 15},
-		"m5dn.4xlarge":  {8, 30, 30},
-		"m5dn.8xlarge":  {8, 30, 30},
-		"m5dn.12xlarge": {8, 30, 30},
-		"m5dn.16xlarge": {8, 30, 30},
-		"m5dn.24xlarge": {15, 50, 50},
-		"m5n.large":     {3, 10, 10},
-		"m5n.xlarge":    {4, 15, 15},
-		"m5n.2xlarge":   {4, 15, 15},
-		"m5n.4xlarge":   {8, 30, 30},
-		"m5n.8xlarge":   {8, 30, 30},
-		"m5n.12xlarge":  {8, 30, 30},
-		"m5n.16xlarge":  {8, 30, 30},
-		"m5n.24xlarge":  {15, 50, 50},
-		// NOTE: m6g family are educated guesses based on a1,
-		// as there is no official guidance from AWS on ENI
-		// limits.
-		"m6g.medium":    {2, 4, 4},
-		"m6g.large":     {3, 10, 10},
-		"m6g.xlarge":    {4, 15, 15},
-		"m6g.2xlarge":   {4, 15, 15},
-		"m6g.4xlarge":   {8, 30, 30},
-		"m6g.8xlarge":   {8, 30, 30},
-		"m6g.12xlarge":  {8, 30, 30},
-		"m6g.16xlarge":  {8, 30, 30},
-		"p2.xlarge":     {4, 15, 15},
-		"p2.8xlarge":    {8, 30, 30},
-		"p2.16xlarge":   {8, 30, 30},
-		"p3.2xlarge":    {4, 15, 15},
-		"p3.8xlarge":    {8, 30, 30},
-		"p3.16xlarge":   {8, 30, 30},
-		"p3dn.24xlarge": {15, 50, 50},
-		"r3.large":      {3, 10, 10},
-		"r3.xlarge":     {4, 15, 15},
-		"r3.2xlarge":    {4, 15, 15},
-		"r3.4xlarge":    {8, 30, 30},
-		"r3.8xlarge":    {8, 30, 30},
-		"r4.large":      {3, 10, 10},
-		"r4.xlarge":     {4, 15, 15},
-		"r4.2xlarge":    {4, 15, 15},
-		"r4.4xlarge":    {8, 30, 30},
-		"r4.8xlarge":    {8, 30, 30},
-		"r4.16xlarge":   {15, 50, 50},
-		"r5.large":      {3, 10, 10},
-		"r5.xlarge":     {4, 15, 15},
-		"r5.2xlarge":    {4, 15, 15},
-		"r5.4xlarge":    {8, 30, 30},
-		"r5.12xlarge":   {8, 30, 30},
-		"r5.24xlarge":   {15, 50, 50},
-		"r5.metal":      {15, 50, 50},
-		"r5a.large":     {3, 10, 10},
-		"r5a.xlarge":    {4, 15, 15},
-		"r5a.2xlarge":   {4, 15, 15},
-		"r5a.4xlarge":   {8, 30, 30},
-		"r5a.12xlarge":  {8, 30, 30},
-		"r5a.24xlarge":  {15, 50, 50},
-		"r5ad.large":    {3, 10, 10},
-		"r5ad.xlarge":   {4, 15, 15},
-		"r5ad.2xlarge":  {4, 15, 15},
-		"r5ad.4xlarge":  {8, 30, 30},
-		"r5ad.12xlarge": {8, 30, 30},
-		"r5ad.24xlarge": {15, 50, 50},
-		"r5d.large":     {3, 10, 10},
-		"r5d.xlarge":    {4, 15, 15},
-		"r5d.2xlarge":   {4, 15, 15},
-		"r5d.4xlarge":   {8, 30, 30},
-		"r5d.12xlarge":  {8, 30, 30},
-		"r5d.24xlarge":  {15, 50, 50},
-		"r5d.metal":     {15, 50, 50},
-		"r5dn.large":    {3, 10, 10},
-		"r5dn.xlarge":   {4, 15, 15},
-		"r5dn.2xlarge":  {4, 15, 15},
-		"r5dn.4xlarge":  {8, 30, 30},
-		"r5dn.8xlarge":  {8, 30, 30},
-		"r5dn.12xlarge": {8, 30, 30},
-		"r5dn.16xlarge": {8, 30, 30},
-		"r5dn.24xlarge": {15, 50, 50},
-		"r5n.large":     {3, 10, 10},
-		"r5n.xlarge":    {4, 15, 15},
-		"r5n.2xlarge":   {4, 15, 15},
-		"r5n.4xlarge":   {8, 30, 30},
-		"r5n.8xlarge":   {8, 30, 30},
-		"r5n.12xlarge":  {8, 30, 30},
-		"r5n.16xlarge":  {8, 30, 30},
-		"r5n.24xlarge":  {15, 50, 50},
-		"t1.micro":      {2, 2, 0},
-		"t2.nano":       {2, 2, 2},
-		"t2.micro":      {2, 2, 2},
-		"t2.small":      {2, 4, 4},
-		"t2.medium":     {3, 6, 6},
-		"t2.large":      {3, 12, 12},
-		"t2.xlarge":     {3, 15, 15},
-		"t2.2xlarge":    {3, 15, 15},
-		"t3.nano":       {2, 2, 2},
-		"t3.micro":      {2, 2, 2},
-		"t3.small":      {3, 4, 4},
-		"t3.medium":     {3, 6, 6},
-		"t3.large":      {3, 12, 12},
-		"t3.xlarge":     {4, 15, 15},
-		"t3.2xlarge":    {4, 15, 15},
-		"t3a.nano":      {2, 2, 2},
-		"t3a.micro":     {2, 2, 2},
-		"t3a.small":     {3, 4, 4},
-		"t3a.medium":    {3, 6, 6},
-		"t3a.large":     {3, 12, 12},
-		"t3a.xlarge":    {4, 15, 15},
-		"t3a.2xlarge":   {4, 15, 15},
-		"u-6tb1.metal":  {5, 30, 30},
-		"u-9tb1.metal":  {5, 30, 30},
-		"u-12tb1.metal": {5, 30, 30},
-		"u-18tb1.metal": {15, 50, 50},
-		"u-24tb1.metal": {15, 50, 50},
-		"x1.16xlarge":   {8, 30, 30},
-		"x1.32xlarge":   {8, 30, 30},
-		"x1e.xlarge":    {3, 10, 10},
-		"x1e.2xlarge":   {4, 15, 15},
-		"x1e.4xlarge":   {4, 15, 15},
-		"x1e.8xlarge":   {4, 15, 15},
-		"x1e.16xlarge":  {8, 30, 30},
-		"x1e.32xlarge":  {8, 30, 30},
-		"z1d.large":     {3, 10, 10},
-		"z1d.xlarge":    {4, 15, 15},
-		"z1d.2xlarge":   {4, 15, 15},
-		"z1d.3xlarge":   {8, 30, 30},
-		"z1d.6xlarge":   {8, 30, 30},
-		"z1d.12xlarge":  {15, 50, 50},
-		"z1d.metal":     {15, 50, 50},
-	}
-}
-
 // ENILimitsForInstanceType returns the limits for ENI for an instance type
-// Returns a zero-limit for unknown instance types
-func ENILimitsForInstanceType(itype string) (limit ENILimit) {
-	limit = eniLimits[itype]
-	return
+func (c *awsclient) ENILimitsForInstanceType(itype string) (ENILimit, error) {
+	client, err := c.newEC2()
+	if err != nil {
+		return ENILimit{}, err
+	}
+
+	itypeList := []string{itype}
+	describeInstanceTypesInput := &ec2.DescribeInstanceTypesInput{
+		InstanceTypes: aws.StringSlice(itypeList),
+	}
+
+	instanceDescribeOutput, err := client.DescribeInstanceTypes(describeInstanceTypesInput)
+	if err != nil {
+		return ENILimit{}, err
+	}
+	if len(instanceDescribeOutput.InstanceTypes) == 0 {
+		return ENILimit{}, fmt.Errorf("empty answer from DescribeInstanceTypes for %s", itype)
+	}
+
+	netInfo := instanceDescribeOutput.InstanceTypes[0].NetworkInfo
+	limit := ENILimit{
+		Adapters: *netInfo.MaximumNetworkInterfaces,
+		IPv4:     *netInfo.Ipv4AddressesPerInterface,
+		IPv6:     *netInfo.Ipv6AddressesPerInterface,
+	}
+	return limit, nil
 }
 
 // ENILimits returns the limits based on the system's instance type
@@ -285,5 +56,20 @@ func (c *awsclient) ENILimits() ENILimit {
 	if err != nil || id == nil {
 		return ENILimit{}
 	}
-	return ENILimitsForInstanceType(id.InstanceType)
+
+	// Use the instance type in the cache key in case at some point the cache dir is persisted across reboots
+	// (instances can be stopped and resized)
+	key := "eni_limits_for_" + id.InstanceType
+	limit := ENILimit{}
+	if cache.Get(key, &limit) == cache.CacheFound {
+		return limit
+	}
+
+	limit, err = c.ENILimitsForInstanceType(id.InstanceType)
+	if err != nil {
+		return ENILimit{}
+	}
+
+	cache.Store(key, 24*time.Hour, limit)
+	return limit
 }

--- a/aws/limits_test.go
+++ b/aws/limits_test.go
@@ -28,10 +28,10 @@ func TestLimitsReturn(t *testing.T) {
 	cases := []struct {
 		iType    string
 		Resp     ec2.DescribeInstanceTypesOutput
-		Expected ENILimit
+		Expected *ENILimit
 	}{
 		{
-			Expected: ENILimit{
+			Expected: &ENILimit{
 				Adapters: 4,
 				IPv4:     15,
 				IPv6:     15,
@@ -50,7 +50,7 @@ func TestLimitsReturn(t *testing.T) {
 			},
 		},
 		{
-			Expected: ENILimit{
+			Expected: &ENILimit{
 				Adapters: 15,
 				IPv4:     50,
 				IPv6:     50,
@@ -81,14 +81,14 @@ func TestLimitsReturn(t *testing.T) {
 		}
 		defaultClient.ec2Client = mock
 
-		res := defaultClient.ENILimits()
+		res, _ := defaultClient.ENILimits()
 		if !reflect.DeepEqual(res, c.Expected) {
 			t.Fatalf("ENILimits do not match. Expected: %v Got: %v", c.Expected, res)
 		}
 
 		calls := mock.InstanceTypesDescribeCalls
 
-		res = defaultClient.ENILimits()
+		res, _ = defaultClient.ENILimits()
 		if mock.InstanceTypesDescribeCalls != calls {
 			t.Fatalf("Caching logic failed, API call made")
 		}

--- a/aws/limits_test.go
+++ b/aws/limits_test.go
@@ -1,23 +1,99 @@
 package aws
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 )
+
+type ec2InstanceTypesMock struct {
+	ec2iface.EC2API
+	InstanceTypesDescribeResp  ec2.DescribeInstanceTypesOutput
+	InstanceTypesDescribeCalls int
+}
+
+func (e *ec2InstanceTypesMock) DescribeInstanceTypes(in *ec2.DescribeInstanceTypesInput) (*ec2.DescribeInstanceTypesOutput, error) {
+	e.InstanceTypesDescribeCalls++
+	return &e.InstanceTypesDescribeResp, nil
+}
 
 func TestLimitsReturn(t *testing.T) {
 	oldIDDoc := defaultClient.idDoc
 	defer func() { defaultClient.idDoc = oldIDDoc }()
 
-	defaultClient.idDoc = &ec2metadata.EC2InstanceIdentityDocument{
-		Region:           "us-east-1",
-		AvailabilityZone: "us-east-1a",
-		InstanceType:     "r4.xlarge",
+	cases := []struct {
+		iType    string
+		Resp     ec2.DescribeInstanceTypesOutput
+		Expected ENILimit
+	}{
+		{
+			Expected: ENILimit{
+				Adapters: 4,
+				IPv4:     15,
+				IPv6:     15,
+			},
+			iType: "r4.xlarge",
+			Resp: ec2.DescribeInstanceTypesOutput{
+				InstanceTypes: []*ec2.InstanceTypeInfo{
+					{
+						NetworkInfo: &ec2.NetworkInfo{
+							Ipv4AddressesPerInterface: aws.Int64(15),
+							Ipv6AddressesPerInterface: aws.Int64(15),
+							MaximumNetworkInterfaces:  aws.Int64(4),
+						},
+					},
+				},
+			},
+		},
+		{
+			Expected: ENILimit{
+				Adapters: 15,
+				IPv4:     50,
+				IPv6:     50,
+			},
+			iType: "c5n.18xlarge",
+			Resp: ec2.DescribeInstanceTypesOutput{
+				InstanceTypes: []*ec2.InstanceTypeInfo{
+					{
+						NetworkInfo: &ec2.NetworkInfo{
+							Ipv4AddressesPerInterface: aws.Int64(50),
+							Ipv6AddressesPerInterface: aws.Int64(50),
+							MaximumNetworkInterfaces:  aws.Int64(15),
+						},
+					},
+				},
+			},
+		},
 	}
 
-	limits := defaultClient.ENILimits()
-	if limits.Adapters != 4 && limits.IPv4 != 15 {
-		t.Fatalf("No valid limit returned for r4.xlarge %v", limits)
+	for _, c := range cases {
+		defaultClient.idDoc = &ec2metadata.EC2InstanceIdentityDocument{
+			Region:           "us-east-1",
+			AvailabilityZone: "us-east-1a",
+			InstanceType:     c.iType,
+		}
+		mock := &ec2InstanceTypesMock{
+			InstanceTypesDescribeResp: c.Resp,
+		}
+		defaultClient.ec2Client = mock
+
+		res := defaultClient.ENILimits()
+		if !reflect.DeepEqual(res, c.Expected) {
+			t.Fatalf("ENILimits do not match. Expected: %v Got: %v", c.Expected, res)
+		}
+
+		calls := mock.InstanceTypesDescribeCalls
+
+		res = defaultClient.ENILimits()
+		if mock.InstanceTypesDescribeCalls != calls {
+			t.Fatalf("Caching logic failed, API call made")
+		}
+		if !reflect.DeepEqual(res, c.Expected) {
+			t.Fatalf("ENILimits from cache do not match. Expected: %v Got: %v", c.Expected, res)
+		}
 	}
 }

--- a/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
+++ b/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
@@ -159,7 +159,10 @@ func actionFreeIps(c *cli.Context) error {
 }
 
 func actionLimits(c *cli.Context) error {
-	limit := aws.DefaultClient.ENILimits()
+	limit, err := aws.DefaultClient.ENILimits()
+	if err != nil {
+		return err
+	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "adapters\tipv4\tipv6\t")
 	fmt.Fprintf(w, "%v\t%v\t%v\t\n", limit.Adapters,
@@ -170,7 +173,10 @@ func actionLimits(c *cli.Context) error {
 }
 
 func actionMaxPods(c *cli.Context) error {
-	limit := aws.DefaultClient.ENILimits()
+	limit, err := aws.DefaultClient.ENILimits()
+	if err != nil {
+		return err
+	}
 	specifiedMax := int64(c.Int("max"))
 	max := (limit.Adapters - 1) * limit.IPv4
 	if specifiedMax > 0 && specifiedMax < max {

--- a/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
+++ b/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
@@ -171,7 +171,7 @@ func actionLimits(c *cli.Context) error {
 
 func actionMaxPods(c *cli.Context) error {
 	limit := aws.DefaultClient.ENILimits()
-	specifiedMax := c.Int("max")
+	specifiedMax := int64(c.Int("max"))
 	max := (limit.Adapters - 1) * limit.IPv4
 	if specifiedMax > 0 && specifiedMax < max {
 		// Limit the maximum to the CLI maximum

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/Microsoft/go-winio v0.4.11
 	github.com/alecthomas/units v0.0.0-20190910110746-680d30ca3117 // indirect
-	github.com/aws/aws-sdk-go v1.12.79
+	github.com/aws/aws-sdk-go v1.28.1
 	github.com/containernetworking/cni v0.6.0
 	github.com/containernetworking/plugins v0.7.4
 	github.com/coreos/go-iptables v0.4.0
@@ -17,7 +17,7 @@ require (
 	github.com/golangci/golangci-lint v1.18.0 // indirect
 	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf // indirect
 	github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56
-	github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8
+	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 	github.com/nightlyone/lockfile v0.0.0-20180618180623-0ad87eef1443
 	github.com/pkg/errors v0.8.1
 	github.com/urfave/cli v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/OpenPeeDeeP/depguard v1.0.0/go.mod h1:7/4sitnI9YlQgTLLk734QlzXT8DuHVn
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/alecthomas/units v0.0.0-20190910110746-680d30ca3117 h1:aUo+WrWZtRRfc6WITdEKzEczFRlEpfW15NhNeLRc17U=
 github.com/alecthomas/units v0.0.0-20190910110746-680d30ca3117/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/aws/aws-sdk-go v1.12.79 h1:vVHvlFso5qhjZrp6z03WGoMwq9QFLOk7WY3Hf653l5I=
-github.com/aws/aws-sdk-go v1.12.79/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoMu1ADI3k=
+github.com/aws/aws-sdk-go v1.28.1 h1:aWBD5EJrmGFuHFn9ZdaHqWWZGZYQ5Gzb3j9G0RppLpY=
+github.com/aws/aws-sdk-go v1.28.1/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/containernetworking/cni v0.6.0 h1:FXICGBZNMtdHlW65trpoHviHctQD3seWhRRcqp2hMOU=
 github.com/containernetworking/cni v0.6.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/plugins v0.7.4 h1:ugkuXfg1Pdzm54U5DGMzreYIkZPSCmSq4rm5TIXVICA=
@@ -110,6 +110,8 @@ github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56 h1:742eGXur0715JMq73
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 h1:12VvqtR6Aowv3l/EQUlocDHW2Cp4G9WJVH7uyH8QFJE=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/kisielk/gotool v0.0.0-20161130080628-0de1eaf82fa3/go.mod h1:jxZFDH7ILpTPQTk+E2s+z4CUas9lVNjIuKR4c5/zKgM=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=


### PR DESCRIPTION
This PR has 2 commits:

Dynamically get instance network limits
- Update the AWS sdk and dependencies
- Get network limits using the DescribeInstanceTypes API (to avoid hard coding the instance network setup).
- Cache the result 24h (we could probably do more) to avoid an API call for every pod
- int -> int64 to match the answer from AWS
- Add API mock for test and include test for caching logic

Propagate errors due to network limits
When an instance was unknown, ENILimits used to return {0,0,0} which was a bit confusing in runtime log. The other commit makes an API call to AWS so we can face new errors. This commits propagate errors to ENILimits callers to make them explicit
 