### PR TITLE
Default IPBatchSize to 1 (previous behavior)

### DIFF
--- a/aws/interface.go
+++ b/aws/interface.go
@@ -61,12 +61,15 @@ func (c *interfaceClient) NewInterfaceOnSubnetAtIndex(index int, secGrps []strin
 	if err != nil {
 		return nil, err
 	}
-	ipv4Limit := limits.IPv4 - 1
 
 	// batch size 0 conventionally means "request the limit"
-	if ipBatchSize == 0 || ipBatchSize > ipv4Limit {
-		createReq.SecondaryPrivateIpAddressCount = &ipv4Limit
-	} else {
+	if ipBatchSize == 0 || ipBatchSize > limits.IPv4 {
+		ipBatchSize = limits.IPv4
+	}
+
+	// We will already get a primary IP on the ENI
+	ipBatchSize = ipBatchSize - 1
+	if ipBatchSize > 0 {
 		createReq.SecondaryPrivateIpAddressCount = &ipBatchSize
 	}
 

--- a/plugin/ipam/main.go
+++ b/plugin/ipam/main.go
@@ -60,6 +60,7 @@ func init() {
 func parseConfig(stdin []byte) (*PluginConf, error) {
 	conf := PluginConf{
 		ReuseIPWait: 60, // default 60 second wait
+		IPBatchSize: 1,  // default 1 (backward compatibility)
 	}
 
 	if err := json.Unmarshal(stdin, &conf); err != nil {


### PR DESCRIPTION
Addresses #77 : when ipBatchSize is not set, default to 1 (explicitly using 0 will still allocate all possible IPs)

In addition, request `ipBatchSize-1` IPs when creating a new interface (it will come a primary address)

cc @theatrus 