### PR TITLE
Handle unavailability of limits

### DIFF
--- a/aws/allocate.go
+++ b/aws/allocate.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"sort"
 	"time"
@@ -41,7 +42,7 @@ func (c *allocateClient) AllocateIPsOn(intf Interface, batchSize int64) ([]*Allo
 
 	limits, err := c.aws.ENILimits()
 	if err != nil {
-		return nil, err
+		log.Printf("unable to determine AWS limits, using fallback %v", err)
 	}
 	available := limits.IPv4 - int64(len(intf.IPv4s))
 
@@ -108,7 +109,7 @@ func (c *allocateClient) AllocateIPsFirstAvailableAtIndex(index int, batchSize i
 	}
 	limits, err := c.aws.ENILimits()
 	if err != nil {
-		return nil, err
+		log.Printf("unable to determine AWS limits, using fallback %v", err)
 	}
 
 	var candidates []Interface

--- a/aws/interface.go
+++ b/aws/interface.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"sort"
@@ -59,7 +60,7 @@ func (c *interfaceClient) NewInterfaceOnSubnetAtIndex(index int, secGrps []strin
 	// Subtract 1 to Account for primary IP
 	limits, err := c.aws.ENILimits()
 	if err != nil {
-		return nil, err
+		log.Printf("unable to determine AWS limits, using fallback %v", err)
 	}
 
 	// batch size 0 conventionally means "request the limit"
@@ -175,7 +176,7 @@ func (c *interfaceClient) NewInterface(secGrps []string, requiredTags map[string
 
 	limits, err := c.aws.ENILimits()
 	if err != nil {
-		return nil, err
+		log.Printf("unable to determine AWS limits, using fallback %v", err)
 	}
 	if int64(len(existingInterfaces)) >= limits.Adapters {
 		return nil, fmt.Errorf("too many adapters on this instance already")

--- a/aws/limits.go
+++ b/aws/limits.go
@@ -22,6 +22,12 @@ type LimitsClient interface {
 	ENILimits() (*ENILimit, error)
 }
 
+var defaultLimit = ENILimit{
+	Adapters: 4,
+	IPv4:     15,
+	IPv6:     15,
+}
+
 // ENILimitsForInstanceType returns the limits for ENI for an instance type
 func (c *awsclient) ENILimitsForInstanceType(itype string) (*ENILimit, error) {
 	client, err := c.newEC2()
@@ -55,7 +61,7 @@ func (c *awsclient) ENILimitsForInstanceType(itype string) (*ENILimit, error) {
 func (c *awsclient) ENILimits() (*ENILimit, error) {
 	id, err := c.getIDDoc()
 	if err != nil || id == nil {
-		return nil, errors.Wrap(err, "unable get instance identity doc")
+		return &defaultLimit, errors.Wrap(err, "unable get instance identity doc")
 	}
 
 	// Use the instance type in the cache key in case at some point the cache dir is persisted across reboots
@@ -68,7 +74,7 @@ func (c *awsclient) ENILimits() (*ENILimit, error) {
 
 	limit, err = c.ENILimitsForInstanceType(id.InstanceType)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable get instance network limits")
+		return &defaultLimit, errors.Wrap(err, "unable get instance network limits")
 	}
 
 	cache.Store(key, 24*time.Hour, limit)

--- a/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
+++ b/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
@@ -174,8 +174,14 @@ func actionLimits(c *cli.Context) error {
 
 func actionMaxPods(c *cli.Context) error {
 	limit, err := aws.DefaultClient.ENILimits()
+	retErr := c.Bool("return-error")
 	if err != nil {
-		return err
+		if retErr {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "unable to determine ENI limit due to '%v', defaulting max pods to 110", err)
+		fmt.Printf("%d\n", 110)
+		return nil
 	}
 	specifiedMax := int64(c.Int("max"))
 	max := (limit.Adapters - 1) * limit.IPv4

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/Microsoft/go-winio v0.4.11
 	github.com/alecthomas/units v0.0.0-20190910110746-680d30ca3117 // indirect
-	github.com/aws/aws-sdk-go v1.28.1
+	github.com/aws/aws-sdk-go v1.29.27
 	github.com/containernetworking/cni v0.6.0
 	github.com/containernetworking/plugins v0.7.4
 	github.com/coreos/go-iptables v0.4.0
@@ -19,11 +19,11 @@ require (
 	github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 	github.com/nightlyone/lockfile v0.0.0-20180618180623-0ad87eef1443
-	github.com/pkg/errors v0.8.1
+	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli v1.20.0
 	github.com/vishvananda/netlink v1.0.0
 	github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc
-	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
+	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	golang.org/x/sys v0.0.0-20190312061237-fead79001313
 	gopkg.in/alecthomas/gometalinter.v2 v2.0.12 // indirect
 	gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/alecthomas/units v0.0.0-20190910110746-680d30ca3117 h1:aUo+WrWZtRRfc6
 github.com/alecthomas/units v0.0.0-20190910110746-680d30ca3117/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aws/aws-sdk-go v1.28.1 h1:aWBD5EJrmGFuHFn9ZdaHqWWZGZYQ5Gzb3j9G0RppLpY=
 github.com/aws/aws-sdk-go v1.28.1/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.29.27 h1:4A53lDDGtk4TvnXFzvcOO3Vx3tDqEPfwvChhhxTPN/M=
+github.com/aws/aws-sdk-go v1.29.27/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
 github.com/containernetworking/cni v0.6.0 h1:FXICGBZNMtdHlW65trpoHviHctQD3seWhRRcqp2hMOU=
 github.com/containernetworking/cni v0.6.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/plugins v0.7.4 h1:ugkuXfg1Pdzm54U5DGMzreYIkZPSCmSq4rm5TIXVICA=
@@ -35,6 +37,7 @@ github.com/go-ini/ini v1.39.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3I
 github.com/go-lintpack/lintpack v0.5.2 h1:DI5mA3+eKdWeJ40nU4d6Wc26qmdG8RCi/btYq0TuRN0=
 github.com/go-lintpack/lintpack v0.5.2/go.mod h1:NwZuYi2nUHho8XEIZ6SIxihrnPoqBTDqfpXvXAN0sXM=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-toolsmith/astcast v1.0.0 h1:JojxlmI6STnFVG9yOImLeGREv8W2ocNUM+iOhR6jE7g=
 github.com/go-toolsmith/astcast v1.0.0/go.mod h1:mt2OdQTeAQcY4DQgPSArJjHCcOwlX+Wl/kwN+LbLGQ4=
 github.com/go-toolsmith/astcopy v1.0.0 h1:OMgl1b1MEpjFQ1m5ztEO06rz5CUd3oBv9RF7+DyvdG8=
@@ -152,6 +155,8 @@ github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -204,6 +209,8 @@ golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20171026204733-164713f0dfce/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
Sometimes, the AWS API does not know about an instance type that
should exist, so lets make sure to always do "something" and not block
all pods and network activity.