### PR TITLE
registry: Record IPs as free at the epoch when allocating an interface

### DIFF
--- a/aws/interface.go
+++ b/aws/interface.go
@@ -130,7 +130,7 @@ func (c *interfaceClient) NewInterfaceOnSubnetAtIndex(index int, secGrps []strin
 				// Timestamp the addition of all the new IPs in the registry.
 				for _, privateIPAddress := range resp.NetworkInterface.PrivateIpAddresses {
 					if privateIPAddr := net.ParseIP(*privateIPAddress.PrivateIpAddress); privateIPAddr != nil {
-						registry.TrackIP(privateIPAddr)
+						registry.TrackIPAtEpoch(privateIPAddr)
 					}
 				}
 				// Interfaces are sorted by device number. The first one is the main one

--- a/aws/registry.go
+++ b/aws/registry.go
@@ -142,6 +142,21 @@ func (r *Registry) save(rc *registryContents) error {
 	return err
 }
 
+// TrackIPAtEpoch sets the IP recorded time as the epoch (0 time)
+// so it appears as immediately free and avoids re-allocation
+func (r *Registry) TrackIPAtEpoch(ip net.IP) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	contents, err := r.load()
+	if err != nil {
+		return err
+	}
+
+	contents.IPs[ip.String()] = &registryIP{lib.JSONTime{time.Time{}}}
+	return r.save(contents)
+}
+
 // TrackIP records an IP in the free registry with the current system
 // time as the current freed-time. If an IP is freed again, the time
 // will be updated to the new current time.


### PR DESCRIPTION
Currently, they are timestamped at Now(), which means IPs allocated in
batch are not available as "free" immediately, and much wait the 30s
default dwell time.