### PR TITLE
Fix cniVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,11 +216,11 @@ not a dependency of this software.
 
 ```
 {
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.4.0",
     "name": "cni-ipvlan-vpc-k8s",
     "plugins": [
 	{
-	    "cniVersion": "0.3.1",
+	    "cniVersion": "0.4.0",
 	    "type": "cni-ipvlan-vpc-k8s-ipam",
 	    "interfaceIndex": 1,
 	    "subnetTags": {
@@ -232,12 +232,12 @@ not a dependency of this software.
 	    ]
 	},
 	{
-	    "cniVersion": "0.3.1",
+	    "cniVersion": "0.4.0",
 	    "type": "cni-ipvlan-vpc-k8s-ipvlan",
 	    "mode": "l2"
 	},
 	{
-	    "cniVersion": "0.3.1",
+	    "cniVersion": "0.4.0",
 	    "type": "cni-ipvlan-vpc-k8s-unnumbered-ptp",
 	    "hostInterface": "eth0",
 	    "containerInterface": "eth1",


### PR DESCRIPTION
While trying the latest version, we got the following error

```
 Warning  FailedCreatePodSandBox  16m                 kubelet, ip-172-17-224-226.eu-central-1.compute.internal  Failed create pod sandbox: rpc error: code = Unknown desc = [failed to set up sandbox container "45dbad7ae1fb8123ffe3832ea1c007e277006a3cc710a16143fa5b0145c79d01" network for pod "fluentd-splunk-9h7bm": NetworkPlugin cni failed to set up pod "fluentd-splunk-9h7bm_kube-system" network: incompatible CNI versions; config is "0.3.1", plugin supports ["0.4.0"], failed to clean up sandbox container "45dbad7ae1fb8123ffe3832ea1c007e277006a3cc710a16143fa5b0145c79d01" network for pod "fluentd-splunk-9h7bm": NetworkPlugin cni failed to teardown pod "fluentd-splunk-9h7bm_kube-system" network: couldn't discover peer idx from netns /proc/7171/ns/net: failed to lookup "veth0": could not look up "veth0": Link not found]
```

This is because https://github.com/lyft/cni-ipvlan-vpc-k8s/pull/83 updated the `github.com/containernetworking/cni` package. This is setting the current CNI version to `0.4.0` as per https://github.com/containernetworking/cni/blob/v0.7.1/pkg/version/version.go#L28

This PR fix the README with the correct instructions.

Marked as draft because we're testing to see if we need to make any other change.