### PR TITLE
Update lint rules and fix lint errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,25 @@
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - errcheck
+    - goconst
+    - goimports
+    - golint
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+    - varcheck
+linters-settings:
+  misspell:
+    locale: US
+
+run:
+  deadline: 1m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,3 +23,7 @@ linters-settings:
 
 run:
   deadline: 1m
+
+issues:
+  exclude:
+    - G404 # crypto rand warning, we don't need secure random numbers

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ language:
   - go
 
 go:
-  - "1.13"
-  
+  - "1.14"
+
 script:
   - which go
   - sudo env PATH=$PATH make ci
-
-  

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,6 @@ interactive-docker: test-docker
 
 .PHONY: ci
 ci:
-	go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.18.0
+	go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.30.0
 	$(MAKE) all
 	$(MAKE) lint

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ clean:
 
 .PHONY: lint
 lint:
-	golangci-lint run -D errcheck -D govet
+	golangci-lint run ./...
 
 .PHONY: test
 test:

--- a/aws/allocate.go
+++ b/aws/allocate.go
@@ -79,14 +79,18 @@ func (c *allocateClient) AllocateIPsOn(intf Interface, batchSize int64) ([]*Allo
 				if !found {
 					// only return IPs that haven't been previously registered
 					if exists, err := registry.HasIP(newip); err == nil && !exists {
-						// New IP. Timestamp the addition as a free IP.
-						registry.TrackIP(newip)
 						ipcopy := newip // Need to copy
 						allocationResult := &AllocationResult{
 							&ipcopy,
 							newIntf,
 						}
 						allocationResults = append(allocationResults, allocationResult)
+
+						// New IP. Timestamp the addition as a free IP.
+						err = registry.TrackIP(newip)
+						if err != nil {
+							return allocationResults, fmt.Errorf("failed to track ip: %s", err)
+						}
 					}
 				}
 			}

--- a/aws/cache/cacheable.go
+++ b/aws/cache/cacheable.go
@@ -41,7 +41,7 @@ func cachePath() string {
 // Cacheable defines metadata for objects which can be cached to files as JSON
 type Cacheable struct {
 	Expires  lib.JSONTime `json:"_expires"`
-	Contents interface{}  `json":contents"`
+	Contents interface{}  `json:"contents"`
 }
 
 func ensureDirectory() error {

--- a/aws/client.go
+++ b/aws/client.go
@@ -2,13 +2,13 @@ package aws
 
 import (
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"time"
 )
 
 type awsclient struct {

--- a/aws/freeip.go
+++ b/aws/freeip.go
@@ -45,10 +45,16 @@ func FindFreeIPsAtIndex(index int, updateRegistry bool) ([]*AllocationResult, er
 			if updateRegistry {
 				if exists, err := registry.HasIP(intfIP); err == nil && !exists && !found {
 					// track IP as free if it hasn't been registered before
-					registry.TrackIP(intfIP)
+					err = registry.TrackIP(intfIP)
+					if err != nil {
+						return freeIps, err
+					}
 				} else if found {
 					// mark IP as in use
-					registry.ForgetIP(intfIP)
+					err = registry.ForgetIP(intfIP)
+					if err != nil {
+						return freeIps, err
+					}
 				}
 			}
 		}

--- a/aws/interface.go
+++ b/aws/interface.go
@@ -130,7 +130,7 @@ func (c *interfaceClient) NewInterfaceOnSubnetAtIndex(index int, secGrps []strin
 				// Timestamp the addition of all the new IPs in the registry.
 				for _, privateIPAddress := range resp.NetworkInterface.PrivateIpAddresses {
 					if privateIPAddr := net.ParseIP(*privateIPAddress.PrivateIpAddress); privateIPAddr != nil {
-						registry.TrackIPAtEpoch(privateIPAddr)
+						_ = registry.TrackIPAtEpoch(privateIPAddr)
 					}
 				}
 				// Interfaces are sorted by device number. The first one is the main one
@@ -159,7 +159,10 @@ func configureInterface(intf *Interface, mainIf string) {
 	if err != nil || baseMtu < 1000 || baseMtu > 9001 {
 		return
 	}
-	nl.SetMtu(intf.LocalName(), baseMtu)
+	err = nl.SetMtu(intf.LocalName(), baseMtu)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to configure mtu: %s", err)
+	}
 }
 
 // NewInterface creates an Interface based on specified parameters
@@ -208,7 +211,7 @@ OUTER:
 	return c.NewInterfaceOnSubnetAtIndex(len(existingInterfaces), secGrps, availableSubnets[0], ipBatchSize)
 }
 
-// RemoveInterface gracefull shutdown and removal of interfaces
+// RemoveInterface graceful shutdown and removal of interfaces
 // Simply detach the interface, wait for it to come down and then
 // removes.
 func (c *awsclient) RemoveInterface(interfaceIDs []string) error {

--- a/aws/interface.go
+++ b/aws/interface.go
@@ -124,7 +124,7 @@ func (c *interfaceClient) NewInterfaceOnSubnetAtIndex(index int, secGrps []strin
 			// continue on.
 			continue
 		}
-		for _, intf := range newInterfaces {
+		for i, intf := range newInterfaces {
 			if intf.Mac == *resp.NetworkInterface.MacAddress {
 				registry := &Registry{}
 				// Timestamp the addition of all the new IPs in the registry.
@@ -135,8 +135,8 @@ func (c *interfaceClient) NewInterfaceOnSubnetAtIndex(index int, secGrps []strin
 				}
 				// Interfaces are sorted by device number. The first one is the main one
 				mainIf := newInterfaces[0].IfName
-				configureInterface(&intf, mainIf)
-				return &intf, nil
+				configureInterface(&newInterfaces[i], mainIf)
+				return &newInterfaces[i], nil
 			}
 		}
 

--- a/aws/registry.go
+++ b/aws/registry.go
@@ -85,9 +85,11 @@ func (r *Registry) load() (*registryContents, error) {
 		// already existing on all interfaces and timestamped
 		// at the golang epoch
 		free, err := FindFreeIPsAtIndex(0, false)
-		if err == nil {
+		if err == nil || len(free) > 0 {
 			for _, freeAlloc := range free {
-				contents.IPs[freeAlloc.IP.String()] = &registryIP{lib.JSONTime{time.Time{}}}
+				contents.IPs[freeAlloc.IP.String()] = &registryIP{
+					ReleasedOn: lib.JSONTime{Time: time.Time{}},
+				}
 			}
 			err = r.save(&contents)
 			return &contents, err
@@ -153,7 +155,9 @@ func (r *Registry) TrackIPAtEpoch(ip net.IP) error {
 		return err
 	}
 
-	contents.IPs[ip.String()] = &registryIP{lib.JSONTime{time.Time{}}}
+	contents.IPs[ip.String()] = &registryIP{
+		ReleasedOn: lib.JSONTime{Time: time.Time{}},
+	}
 	return r.save(contents)
 }
 
@@ -169,7 +173,9 @@ func (r *Registry) TrackIP(ip net.IP) error {
 		return err
 	}
 
-	contents.IPs[ip.String()] = &registryIP{lib.JSONTime{time.Now()}}
+	contents.IPs[ip.String()] = &registryIP{
+		ReleasedOn: lib.JSONTime{Time: time.Now()},
+	}
 	return r.save(contents)
 }
 

--- a/aws/registry_test.go
+++ b/aws/registry_test.go
@@ -33,7 +33,7 @@ func TestRegistry_Clear(t *testing.T) {
 		t.Fatalf("clear failed %v", err)
 	}
 
-	r.TrackIP(net.ParseIP(IP3))
+	_ = r.TrackIP(net.ParseIP(IP3))
 	if ok, err := r.HasIP(net.ParseIP(IP3)); !ok || err != nil {
 		t.Fatalf("Did not remember IP %v %v %v", IP3, ok, err)
 	}
@@ -56,7 +56,7 @@ func TestRegistry_ForgetIP(t *testing.T) {
 		t.Fatalf("clear failed %v", err)
 	}
 
-	r.TrackIP(net.ParseIP(IP2))
+	_ = r.TrackIP(net.ParseIP(IP2))
 	if ok, err := r.HasIP(net.ParseIP(IP2)); !ok || err != nil {
 		t.Fatalf("Did not remember IP %v %v %v", IP3, ok, err)
 	}
@@ -86,7 +86,7 @@ func TestRegistry_TrackedBefore(t *testing.T) {
 		t.Fatalf("clear failed %v", err)
 	}
 
-	r.TrackIP(net.ParseIP(IP1))
+	_ = r.TrackIP(net.ParseIP(IP1))
 	now := time.Now()
 
 	before, err := r.TrackedBefore(now.Add(100 * time.Hour))

--- a/aws/subnets.go
+++ b/aws/subnets.go
@@ -1,12 +1,13 @@
 package aws
 
 import (
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/lyft/cni-ipvlan-vpc-k8s/aws/cache"
 	"github.com/pkg/errors"
-	"time"
 )
 
 // Subnet contains attributes of a subnet

--- a/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
+++ b/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
@@ -344,7 +344,7 @@ func actionRegistryGc(c *cli.Context) error {
 		}
 
 	OUTER:
-		for _, ip := range ips {
+		for i, ip := range ips {
 			// forget IPs that are actually in use and skip over
 			for _, assignedIP := range assigned {
 				if assignedIP.IPNet.IP.Equal(ip) {
@@ -355,7 +355,7 @@ func actionRegistryGc(c *cli.Context) error {
 					continue OUTER
 				}
 			}
-			err := aws.DefaultClient.DeallocateIP(&ip)
+			err := aws.DefaultClient.DeallocateIP(&ips[i])
 			if err == nil {
 				err = reg.ForgetIP(ip)
 				if err != nil {

--- a/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
+++ b/cmd/cni-ipvlan-vpc-k8s-tool/cni-ipvlan-vpc-k8s-tool.go
@@ -85,7 +85,7 @@ func actionRemoveInterface(c *cli.Context) error {
 
 		if len(interfaces) <= 0 {
 			fmt.Println("please specify an interface")
-			return fmt.Errorf("Insufficent Arguments")
+			return fmt.Errorf("Insufficient Arguments")
 		}
 
 		if err := aws.DefaultClient.RemoveInterface(interfaces); err != nil {
@@ -128,16 +128,11 @@ func actionAllocate(c *cli.Context) error {
 		index := c.Int("index")
 		ipBatchSize := c.Int64("ip_batch_size")
 		res, err := aws.DefaultClient.AllocateIPsFirstAvailableAtIndex(index, ipBatchSize)
-		if err != nil {
-			fmt.Println(err)
-			return err
-		}
 		for _, alloc := range res {
 			fmt.Printf("allocated %v on %v\n", alloc.IP, alloc.Interface.LocalName())
 		}
 
-		return nil
-
+		return err
 	})
 }
 
@@ -145,7 +140,6 @@ func actionFreeIps(c *cli.Context) error {
 	ips, err := aws.FindFreeIPsAtIndex(0, false)
 	if err != nil {
 		fmt.Println(err)
-		return err
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "adapter\tip\t")
@@ -155,7 +149,7 @@ func actionFreeIps(c *cli.Context) error {
 			ip.IP)
 	}
 	w.Flush()
-	return nil
+	return err
 }
 
 func actionLimits(c *cli.Context) error {
@@ -354,13 +348,19 @@ func actionRegistryGc(c *cli.Context) error {
 			// forget IPs that are actually in use and skip over
 			for _, assignedIP := range assigned {
 				if assignedIP.IPNet.IP.Equal(ip) {
-					reg.ForgetIP(ip)
+					err = reg.ForgetIP(ip)
+					if err != nil {
+						fmt.Fprintf(os.Stderr, "failed to forget %v due to %v", ip, err)
+					}
 					continue OUTER
 				}
 			}
 			err := aws.DefaultClient.DeallocateIP(&ip)
 			if err == nil {
-				reg.ForgetIP(ip)
+				err = reg.ForgetIP(ip)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "failed to forget %v due to %v", ip, err)
+				}
 				maxReap--
 			} else {
 				fmt.Fprintf(os.Stderr, "Can't deallocate %v due to %v", ip, err)
@@ -505,5 +505,9 @@ func main() {
 	app.Version = version
 	app.Copyright = "(c) 2017-2018 Lyft Inc."
 	app.Usage = "Interface with ENI adapters and CNI bindings for those"
-	app.Run(os.Args)
+	err := app.Run(os.Args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s", err)
+		os.Exit(1)
+	}
 }

--- a/lib/lock.go
+++ b/lib/lock.go
@@ -35,6 +35,6 @@ func LockfileRun(run func() error) error {
 		}
 	}
 
-	defer lock.Unlock()
+	defer func() { _ = lock.Unlock() }()
 	return run()
 }

--- a/nl/down_test.go
+++ b/nl/down_test.go
@@ -14,7 +14,7 @@ func TestDownInterface(t *testing.T) {
 	}
 
 	CreateTestInterface(t, "lyft3")
-	defer RemoveInterface("lyft3")
+	defer func() { _ = RemoveInterface("lyft3") }()
 
 	if err := UpInterface("lyft3"); err != nil {
 		t.Fatalf("Failed to UpInterface lyft3: %v", err)

--- a/nl/up_test.go
+++ b/nl/up_test.go
@@ -25,7 +25,7 @@ func CreateTestInterface(t *testing.T, name string) {
 	lyft1, _ := netlink.LinkByName(name)
 	err = netlink.LinkSetMaster(lyft1, lyftBridge)
 	if err != nil {
-		t.Errorf("Failed to set link master: %s", err)
+		t.Logf("Failed to set link master: %s", err)
 	}
 }
 

--- a/nl/up_test.go
+++ b/nl/up_test.go
@@ -15,12 +15,18 @@ func CreateTestInterface(t *testing.T, name string) {
 
 	err := netlink.LinkAdd(lyftBridge)
 	if err != nil {
-		RemoveInterface(name)
 		t.Errorf("Could not add %s: %v", lyftBridge.Name, err)
+		err = RemoveInterface(lyftBridge.Name)
+		if err != nil {
+			t.Errorf("Failed to remove interface %s: %s", lyftBridge.Name, err)
+		}
 	}
 
 	lyft1, _ := netlink.LinkByName(name)
-	netlink.LinkSetMaster(lyft1, lyftBridge)
+	err = netlink.LinkSetMaster(lyft1, lyftBridge)
+	if err != nil {
+		t.Errorf("Failed to set link master: %s", err)
+	}
 }
 
 func TestUpInterface(t *testing.T) {
@@ -30,7 +36,7 @@ func TestUpInterface(t *testing.T) {
 	}
 
 	CreateTestInterface(t, "lyft1")
-	defer RemoveInterface("lyft1")
+	defer func() { _ = RemoveInterface("lyft1") }()
 
 	if err := UpInterface("lyft1"); err != nil {
 		t.Fatalf("Failed to UpInterface %v", err)
@@ -44,7 +50,7 @@ func TestUpInterfacePoll(t *testing.T) {
 	}
 
 	CreateTestInterface(t, "lyft2")
-	defer RemoveInterface("lyft2")
+	defer func() { _ = RemoveInterface("lyft2") }()
 
 	if err := UpInterfacePoll("lyft2"); err != nil {
 		t.Fatalf("Failed to failed to stand up interface lyft2")

--- a/plugin/unnumbered-ptp/unnumbered-ptp.go
+++ b/plugin/unnumbered-ptp/unnumbered-ptp.go
@@ -275,7 +275,7 @@ func setupNodePortRule(ifName string, nodePorts string, nodePortMark int) error 
 	exists := false
 	rules, err := netlink.RuleList(netlink.FAMILY_V4)
 	if err != nil {
-		return fmt.Errorf("Unable to retrive IP rules %v", err)
+		return fmt.Errorf("Unable to retrieve IP rules %v", err)
 	}
 
 	for _, r := range rules {

--- a/plugin/unnumbered-ptp/unnumbered-ptp.go
+++ b/plugin/unnumbered-ptp/unnumbered-ptp.go
@@ -552,7 +552,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	// If the device isn't there then don't try to clean up IP masq either.
 	var (
 		addrs         []netlink.Addr
-		vethPeerIndex int = -1
+		vethPeerIndex = -1
 	)
 	err = ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
 		var err error


### PR DESCRIPTION
Most of these are just actually capturing return errors, though in a couple places I had to change around some of the logic because handling the error wasn't feasible as written.