### PR TITLE
add routeToCidrs ipam option

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ available:
    to enumerate all peered VPCs. Routes will be added so connections
    to these VPCs will be sourced from the IPvlan adapter in the pod
    and not through the host masquerade.
+ - `routeToCidrs`: List of CIDRs. Routes will be added so connections
+   to these CIDRs will be sourced from the IPvlan adapter in the pod
+   and not through the host masquerade.
 - `reuseIPWait`: Seconds to wait before free IP addresses are made
    available for reuse by Pods. Defaults to 60 seconds. `reuseIPWait`
    functions as both a lock to prevent addresses from being grabbed by

--- a/plugin/ipam/main.go
+++ b/plugin/ipam/main.go
@@ -47,6 +47,7 @@ type PluginConf struct {
 	RouteToVPCPeers  bool              `json:"routeToVpcPeers"`
 	ReuseIPWait      int               `json:"reuseIPWait"`
 	IPBatchSize      int64             `json:"ipBatchSize"`
+	RouteToCidrs     []string          `json:"routeToCidrs"`
 }
 
 func init() {
@@ -184,6 +185,16 @@ func cmdAdd(args *skel.CmdArgs) error {
 			return fmt.Errorf("unable to enumerate peer CIDrs %v", err)
 		}
 		cidrs = append(cidrs, peerCidr...)
+	}
+
+	if conf.RouteToCidrs != nil {
+		for _, cidr := range conf.RouteToCidrs {
+			_, parsed, err := net.ParseCIDR(cidr)
+			if err != nil {
+				return fmt.Errorf("unable to parse routeToCidrs element %v", err)
+			}
+			cidrs = append(cidrs, parsed)
+		}
 	}
 
 	// add routes for all VPC cidrs via the subnet gateway


### PR DESCRIPTION
Support adding CIDRs in ipam config for additional IPvlan adapter routes to be added at Pod creation time. Useful for arbitrary routes that can be handled by the VPC (ex. Transit Gateway routes).