### PR TITLE
pick subnets at psuedorandom, not by most available

### DIFF
--- a/aws/subnets.go
+++ b/aws/subnets.go
@@ -20,7 +20,8 @@ type Subnet struct {
 	Tags                  map[string]string
 }
 
-// SubnetsByAvailableAddressCount contains a list of subnet
+// SubnetsByAvailableAddressCount is a list of subnets sorted by
+// currently available addresses
 type SubnetsByAvailableAddressCount []Subnet
 
 func (a SubnetsByAvailableAddressCount) Len() int      { return len(a) }
@@ -28,6 +29,13 @@ func (a SubnetsByAvailableAddressCount) Swap(i, j int) { a[i], a[j] = a[j], a[i]
 func (a SubnetsByAvailableAddressCount) Less(i, j int) bool {
 	return a[i].AvailableAddressCount > a[j].AvailableAddressCount
 }
+
+// SubnetsByID is a list of subnets sorted by ID
+type SubnetsByID []Subnet
+
+func (a SubnetsByID) Len() int           { return len(a) }
+func (a SubnetsByID) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a SubnetsByID) Less(i, j int) bool { return a[i].ID < a[j].ID }
 
 // SubnetsClient provides information about VPC subnets
 type SubnetsClient interface {


### PR DESCRIPTION
It's possible that when the number of IPs available gets low in a subnet, many instances can request IPs in the same subnet, which result in many IP allocations failing since there are more IPs requested than are available.

Instead, alleviate this issue by picking subnets at psuedo-random, and making sure we retry different subnets on different attempts.